### PR TITLE
BaseItem, BaseMonster, ItemModifier, Quest, Spell, UniqueMonster: Add additional fields, comments, TODOs and pretty-printing, fix error messages, and remove trailing whitespace

### DIFF
--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseItem.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseItem.java
@@ -574,7 +574,7 @@ public class BaseItem {
 		System.out.println("Unique item code: " + uniqueItemCodes[uniqueItemCode]);
 		System.out.println("Byte fourteen: " + byteFourteen);
 		System.out.println("Byte fifteen: " + byteFifteen);
-		System.out.println("Quality level: " + qualityLevels[qualityLevel]);
+		System.out.println("Quality level: " + qualityLevels[(int) qualityLevel]);
 		System.out.println("Durability: " + durability);
 		System.out.println("Min attack damage: " + minAttackDamage);
 		System.out.println("Max attack damage: " + maxAttackDamage);

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseItem.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseItem.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class BaseItem {
-	
+
 	String[] itemTypes = {
 		"invalid",					//00
 		"Weapons",					//01
@@ -14,7 +14,7 @@ public class BaseItem {
 		"Gold",						//04
 		"Novelty items"				//05
 	};
-	
+
 	String[] equipLocations = {
 		"invalid",										//00
 		"One handed (weapons and shields)",				//01
@@ -25,7 +25,7 @@ public class BaseItem {
 		"Amulet",										//06
 		"Unequipable"									//07
 	};
-	
+
 	String[] graphicValues = {
 		"Potion of Full Mana", //00
 		"White Scroll", //01
@@ -197,7 +197,7 @@ public class BaseItem {
 		"Short Battle Bow", // (A7)
 		"Gold" // (A8)
 	};
-	
+
 	String[] itemCodes = {
 			"All other items (novelties, potions, scrolls, books, etc)", //00
 			"Swords", //01
@@ -212,15 +212,21 @@ public class BaseItem {
 			"Staves", //0A
 			"Gold", //0B
 			"Rings", //0C
-			"Amulets" //0D	
+			"Amulets" //0D
 	};
-	
+
 	String[] baseItemActivationTriggers = {
 			"Item will never be found",		//00
 			"Item will be findable",		//01
 			"Findable, 2X occurance rate"	//02
 		};
-	
+
+	String[] qualityLevels = {
+			"Normal", // 00
+			"Magic",  // 01
+			"Unique"  // 02
+		};
+
 	List<Integer> specialEffectCodes = Arrays.asList(
 			0x01000000,
 			0x02000000,
@@ -255,8 +261,8 @@ public class BaseItem {
 			0x00000040,
 			0x00000080);
 
-	
-	
+
+
 	/*
 	Some effects do not work on certain base items
 	0x0100000 = Infravision
@@ -267,11 +273,11 @@ public class BaseItem {
 	0x20000000 = Extra Lighning Damage
 	0x40000000 = Cursed Hit Points
 	0x80000000 = ???
-	0x00010000 = ???
+	0x00010000 = User can't heal
 	0x00020000 = ???
 	0x00040000 = ???
 	0x00080000 = Knock target back
-	0x00100000 = ???
+	0x00100000 = Hit monster doesn't heal
 	0x00200000 = Steal 3% Mana
 	0x00400000 = Steal 5% Mana
 	0x00800000 = Steal 3% Life
@@ -292,7 +298,7 @@ public class BaseItem {
 	0x00000040 = +200% Damage to Demons
 	0x00000080 = Cursed Resistance
 	*/
-	
+
 	/*
 	Magic codes:
 	00 = Nothing
@@ -319,7 +325,7 @@ public class BaseItem {
 	2B = Ear/Heart
 	2C = Spectral Elixir
 	*/
-	
+
 	/*
 	Spell number
 	01 = Firebolt
@@ -359,13 +365,13 @@ public class BaseItem {
 	23 = Blood Star
 	24 = Bone Spirit
 	*/
-	
+
 	/*
 	Use once flag:
 	00 = Nothing
 	01 = Right clicking the item will make it disappear (potions, scrolls, books)
 	*/
-	
+
 	private long activationTrigger;
 	private int itemType;
 	private int equipLocation;
@@ -399,7 +405,7 @@ public class BaseItem {
 	//private byte[] itemBytes;
 	private int slotNumber;
 	private boolean changed;
-	
+
 	public BaseItem(int slotNumber, byte[] itemBytes, ReaderWriter rw) {
 		changed = false;
 		this.slotNumber = slotNumber;
@@ -420,7 +426,7 @@ public class BaseItem {
 			name = "None";
 		} else {
 			namePointer = rw.convertFourBytesToOffset(itemBytes[16], itemBytes[17], itemBytes[18], itemBytes[19]);
-			name = nf.getNameUsingPointer(namePointer);			
+			name = nf.getNameUsingPointer(namePointer);
 		}
 		if((itemBytes[20] + itemBytes[21] + itemBytes[22] + itemBytes[23]) == 0){
 			magicalNamePointer = 0;
@@ -429,6 +435,12 @@ public class BaseItem {
 			magicalNamePointer = rw.convertFourBytesToOffset(itemBytes[20], itemBytes[21], itemBytes[22], itemBytes[23]);
 			magicalName = nf.getNameUsingPointer(magicalNamePointer);
 		}
+		// ### [ NOTE ] ###
+		// qualityLevel occupies only byte itemBytes[24]. The following three
+		// bytes (itemBytes[25], itemBytes[26], itemBytes[27]) are reserved.
+		//
+		// TODO: Update the relevant code to reflect this.
+		// ### [/ NOTE ] ###
 		qualityLevel = rw.convertFourBytesToNumber(itemBytes[24], itemBytes[25], itemBytes[26], itemBytes[27]);
 		durability = rw.convertFourBytesToNumber(itemBytes[28], itemBytes[29], itemBytes[30], itemBytes[31]);
 		minAttackDamage = rw.convertFourBytesToNumber(itemBytes[32], itemBytes[33], itemBytes[34], itemBytes[35]);
@@ -446,7 +458,7 @@ public class BaseItem {
 		priceOne = rw.convertFourBytesToNumber(itemBytes[68], itemBytes[69], itemBytes[70], itemBytes[71]);
 		priceTwo = rw.convertFourBytesToNumber(itemBytes[72], itemBytes[73], itemBytes[74], itemBytes[75]);
 	}
-	
+
 	public byte[] getItemAsBytes(){
 		byte[] bytes = new byte[TomeOfKnowledge.BASE_ITEM_LENGTH_IN_BYTES];
 		bytes[0] = (byte)(activationTrigger >>>  0);
@@ -562,7 +574,7 @@ public class BaseItem {
 		System.out.println("Unique item code: " + uniqueItemCodes[uniqueItemCode]);
 		System.out.println("Byte fourteen: " + byteFourteen);
 		System.out.println("Byte fifteen: " + byteFifteen);
-		System.out.println("Quality level: " + qualityLevel);
+		System.out.println("Quality level: " + qualityLevels[qualityLevel]);
 		System.out.println("Durability: " + durability);
 		System.out.println("Min attack damage: " + minAttackDamage);
 		System.out.println("Max attack damage: " + maxAttackDamage);
@@ -936,7 +948,7 @@ public class BaseItem {
 
 	public void setPriceTwo(long priceTwo) {
 		if(priceTwo >= 0 && priceTwo <= 999999){
-			this.priceTwo = priceTwo;	
+			this.priceTwo = priceTwo;
 			this.setChanged();
 		} else {
 			System.err.println("Error: BaseItem's setPriceTwo() was"

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseItemStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseItemStore.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BaseItemStore {
-	
+
 	ReaderWriter rw;
 	List<BaseItem> baseItems;
 
@@ -25,9 +25,9 @@ public class BaseItemStore {
 			pos = pos + TomeOfKnowledge.BASE_ITEM_LENGTH_IN_BYTES;
 			rw.seek(pos);
 		}
-		
+
 	}
-	
+
 	public byte[] getItemAsBytes(int index){
 		return baseItems.get(index).getItemAsBytes();
 	}
@@ -45,6 +45,6 @@ public class BaseItemStore {
 			rw.writeBytes(itemAsBytes, pos);
 			pos = pos + TomeOfKnowledge.BASE_ITEM_LENGTH_IN_BYTES;
 		}
-		
+
 	}
 }

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseMonster.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseMonster.java
@@ -63,7 +63,7 @@ public class BaseMonster {
 	private boolean changed;
 	private byte[] monsterBytesOrig;
 	int slotNumber;
-	
+
 	public BaseMonster(int slotNumber, byte[] monsterBytes, byte activationByte, ReaderWriter rw) {
 		this.slotNumber = slotNumber;
 		animationSize = rw.convertFourBytesToNumber(monsterBytes[0], monsterBytes[1], monsterBytes[2], monsterBytes[3]);
@@ -92,6 +92,12 @@ public class BaseMonster {
 		name = nf.getNameUsingPointer(namePointer);
 		minDungeonLevel = rw.convertUnsignedByteToInt(monsterBytes[84]);
 		maxDungeonLevel = rw.convertUnsignedByteToInt(monsterBytes[85]);
+		// ### [ NOTE ] ###
+		// monsterItemLevel occupies only byte monsterBytes[86]. The following
+		// byte (monsterBytes[87]) is reserved.
+		//
+		// TODO: Update the relevant code to reflect this.
+		// ### [/ NOTE ] ###
 		monsterItemLevel = rw.convertTwoBytesToInt(monsterBytes[86], monsterBytes[87]);
 		minHitPoints = rw.convertFourBytesToNumber(monsterBytes[88], monsterBytes[89], monsterBytes[90], monsterBytes[91]);
 		maxHitPoints = rw.convertFourBytesToNumber(monsterBytes[92], monsterBytes[93], monsterBytes[94], monsterBytes[95]);
@@ -125,7 +131,7 @@ public class BaseMonster {
 		changed = false;
 		this.monsterBytesOrig = monsterBytes;
 	}
-	
+
 	public MonsterAsBytes getMonsterAsBytes(){
 		byte[] monsterBytes = new byte[TomeOfKnowledge.BASE_MONSTER_LENGTH_IN_BYTES];
 		monsterBytes[0] = (byte)(animationSize >>>  0);
@@ -225,8 +231,8 @@ public class BaseMonster {
 		monsterBytes[90] = (byte)(minHitPoints >>> 16);
 		monsterBytes[91] = (byte)(minHitPoints >>> 24);
 		monsterBytes[92] = (byte)(maxHitPoints >>>  0);
-		monsterBytes[93] = (byte)(maxHitPoints >>>  8); 
-		monsterBytes[94] = (byte)(maxHitPoints >>> 16); 
+		monsterBytes[93] = (byte)(maxHitPoints >>>  8);
+		monsterBytes[94] = (byte)(maxHitPoints >>> 16);
 		monsterBytes[95] = (byte)(maxHitPoints >>> 24);
 		monsterBytes[96] = (byte) attackType1; //attackType1
 		monsterBytes[97] = (byte) attackType2; //attackType2
@@ -272,7 +278,7 @@ public class BaseMonster {
 
 	public void printMonster() {
 		System.out.println( "+--------------------------------------+" + "\n" +
-							"| Slot number: " + slotNumber + " (hex: " + Integer.toHexString(slotNumber) + ")" + "\n" + 
+							"| Slot number: " + slotNumber + " (hex: " + Integer.toHexString(slotNumber) + ")" + "\n" +
 							"| Monster name: " + name + "\n" +
 							"| Enabled: " + enabled + "\n" +
 							"| Animation size: " + animationSize + "\n" +
@@ -361,7 +367,7 @@ public class BaseMonster {
 		return animationFilePointer;
 	}
 
-	
+
 	public void setAnimationFilePointer(long animationFilePointer) {
 		if(animationFilePointer >= 1024 && animationFilePointer <= 7018496){
 			this.animationFilePointer = animationFilePointer;
@@ -435,7 +441,7 @@ public class BaseMonster {
 		} else {
 			System.err.println("Error: BaseMonster's setUsesTrnToModColor() was"
 					+ "supplied with an argument outside the supported range (0 to 1)");
-		} 
+		}
 	}
 
 	public long getTrnPointer() {
@@ -449,7 +455,7 @@ public class BaseMonster {
 		} else {
 			System.err.println("Error: BaseMonster's setUsesTrnPointer() was"
 					+ "supplied with an argument outside the supported range (1024 to 7018496)");
-		} 
+		}
 	}
 
 	public long getIdleFrameset() {
@@ -463,7 +469,7 @@ public class BaseMonster {
 		} else {
 			System.err.println("Error: BaseMonster's setIdleFrameset() was"
 					+ "supplied with an argument outside the supported range (1 to 24)");
-		} 
+		}
 	}
 
 	public long getWalkFrameset() {
@@ -477,7 +483,7 @@ public class BaseMonster {
 		} else {
 			System.err.println("Error: BaseMonster's setWalkFrameset() was"
 					+ "supplied with an argument outside the supported range (1 to 24)");
-		} 
+		}
 	}
 
 	public long getAttackFrameset() {
@@ -731,7 +737,7 @@ public class BaseMonster {
 	}
 
 	public void setAttackType2(int attackType2) {
-		if(attackType2 >= 0 && attackType2 <= 0){	
+		if(attackType2 >= 0 && attackType2 <= 0){
 			this.attackType2 = attackType2;
 			this.setChanged();
 		} else {
@@ -973,7 +979,7 @@ public class BaseMonster {
 			this.monsterType = monsterType;
 			this.setChanged();
 		} else {
-			System.err.println("Error: BaseMonster's setMonsterAc() was"
+			System.err.println("Error: BaseMonster's setMonsterType() was"
 					+ "supplied with an argument outside the supported range (0 to 3)");
 		}
 	}

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseMonsterStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/BaseMonsterStore.java
@@ -7,7 +7,7 @@ public class BaseMonsterStore {
 
 	ReaderWriter rw;
 	List<BaseMonster> baseMonsters;
-	
+
 	public BaseMonsterStore(ReaderWriter rw) {
 		this.rw = rw;
 		baseMonsters = new ArrayList<BaseMonster>();
@@ -29,16 +29,16 @@ public class BaseMonsterStore {
 			rw.seek(pos);
 		}
 	}
-	
+
 	public MonsterAsBytes getMonsterAsBytes(int index){
 		return baseMonsters.get(index).getMonsterAsBytes();
 	}
-	
+
 	public void printMonsters() {
 		for(BaseMonster bm : baseMonsters){
 			bm.printMonster();
 		}
-		
+
 	}
 
 	public void writeMonstersToEXE() {

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/BinEditHelper.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/BinEditHelper.java
@@ -5,9 +5,9 @@ import java.util.Arrays;
 public class BinEditHelper {
 
 	public BinEditHelper(){
-		
+
 	}
-	
+
 	public String getNameUsingPointer(long pointer){
 		ReaderWriter rwTemp = new ReaderWriter(true);
 		rwTemp.seek(pointer);
@@ -27,7 +27,7 @@ public class BinEditHelper {
 		}
 		return name;
 	}
-	
+
 	//TODO -- replace/simplify much content from the get<ObjectName>AsBytes methods using this method
 	public void setLongAsFourBytes(long numberToConvert, byte[] destinationArray, int firstDestinationByte){
 		byte[] bytesToSet = new byte[4];

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/Character.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/Character.java
@@ -23,9 +23,9 @@ public class Character {
 	private int townWalkFrameset;
 	private int oneHandedAttackSpeed;
 	private int castingSpeed;
-	
+
 	/*
-	0 	
+	0
 	1 	Attacking frameset
 	2 	Walking frameset in dungeon
 	3 	Blocking speed
@@ -34,14 +34,14 @@ public class Character {
 	6 	Hit recovery speed
 	7 	Idle frameset in town
 	8 	Walking frameset in town
-	9 	Single handed weapon attacking speed 
+	9 	Single handed weapon attacking speed
 	10 	Spell casting speed
 	*/
-	
+
 	public Character(){
-		
+
 	}
-	
+
 	public void printCharacter() {
 		System.out.println("Class: " + className);
 		System.out.println("STR: " + initStrength + "--" + maxStrength);

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/CharacterStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/CharacterStore.java
@@ -15,7 +15,7 @@ public class CharacterStore {
 	byte[] maxStats;
 	byte[] blockingBonuses;
 	byte[] bonusesAndFramesets;
-	
+
 	public CharacterStore(ReaderWriter rw) {
 		this.rw = rw;
 		characters = new ArrayList<Character>();
@@ -31,7 +31,7 @@ public class CharacterStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		long initWarriorStrength = rw.convertFourBytesToNumber(startingStats[0], startingStats[1], startingStats[2], startingStats[3]);
 		long initRogueStrength = rw.convertFourBytesToNumber(startingStats[4], startingStats[5], startingStats[6], startingStats[7]);
 		long initSorcStrength = rw.convertFourBytesToNumber(startingStats[8], startingStats[9], startingStats[10], startingStats[11]);
@@ -44,7 +44,7 @@ public class CharacterStore {
 		long initWarriorVitality = rw.convertFourBytesToNumber(startingStats[36], startingStats[37], startingStats[38], startingStats[39]);
 		long initRogueVitality = rw.convertFourBytesToNumber(startingStats[40], startingStats[41], startingStats[42], startingStats[43]);
 		long initSorcVitality = rw.convertFourBytesToNumber(startingStats[44], startingStats[45], startingStats[46], startingStats[47]);
-		
+
 		pos = TomeOfKnowledge.MAX_STATS_OFFSET;
 		rw.seek(pos);
 		maxStats = new byte[48];
@@ -53,7 +53,7 @@ public class CharacterStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		long maxWarriorStrength = rw.convertFourBytesToNumber(maxStats[0], maxStats[1], maxStats[2], maxStats[3]);
 		long maxWarriorMagic = rw.convertFourBytesToNumber(maxStats[4], maxStats[5], maxStats[6], maxStats[7]);
 		long maxWarriorDexterity = rw.convertFourBytesToNumber(maxStats[8], maxStats[9], maxStats[10], maxStats[11]);
@@ -66,7 +66,7 @@ public class CharacterStore {
 		long maxSorcMagic = rw.convertFourBytesToNumber(maxStats[36], maxStats[37], maxStats[38], maxStats[39]);
 		long maxSorcDexterity = rw.convertFourBytesToNumber(maxStats[40], maxStats[41], maxStats[42], maxStats[43]);
 		long maxSorcVitality = rw.convertFourBytesToNumber(maxStats[44], maxStats[45], maxStats[46], maxStats[47]);
-		
+
 		pos = TomeOfKnowledge.BLOCKING_BONUSES_OFFSET;
 		rw.seek(pos);
 		blockingBonuses = new byte[12];
@@ -75,11 +75,11 @@ public class CharacterStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		long warriorBlockingBonus = rw.convertFourBytesToNumber(blockingBonuses[0], blockingBonuses[1], blockingBonuses[2], blockingBonuses[3]);
 		long rogueBlockingBonus = rw.convertFourBytesToNumber(blockingBonuses[4], blockingBonuses[5], blockingBonuses[6], blockingBonuses[7]);
 		long sorcBlockingBonus = rw.convertFourBytesToNumber(blockingBonuses[8], blockingBonuses[9], blockingBonuses[10], blockingBonuses[11]);
-		
+
 		pos = TomeOfKnowledge.BONUSES_AND_FRAMESETS_OFFSET;
 		rw.seek(pos);
 		bonusesAndFramesets = new byte[33];
@@ -88,7 +88,7 @@ public class CharacterStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		/*
 		0 	Idle frameset in the dungeon
 		1 	Attacking frameset
@@ -99,10 +99,10 @@ public class CharacterStore {
 		6 	Hit recovery speed
 		7 	Idle frameset in town
 		8 	Walking frameset in town
-		9 	Single handed weapon attacking speed 
+		9 	Single handed weapon attacking speed
 		10 	Spell casting speed
 		*/
-		
+
 		int warriorDungeonIdleFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[0]);
 		int warriorAttackingFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[1]);
 		int warriorDungeonWalkFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[2]);
@@ -114,7 +114,7 @@ public class CharacterStore {
 		int warriorTownWalkFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[8]);
 		int warrior1hAttackSpeed = rw.convertUnsignedByteToInt(bonusesAndFramesets[9]);
 		int warriorCastingSpeed = rw.convertUnsignedByteToInt(bonusesAndFramesets[10]);
-		
+
 		int rogueDungeonIdleFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[11]);
 		int rogueAttackingFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[12]);
 		int rogueDungeonWalkFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[13]);
@@ -126,7 +126,7 @@ public class CharacterStore {
 		int rogueTownWalkFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[19]);
 		int rogue1hAttackSpeed = rw.convertUnsignedByteToInt(bonusesAndFramesets[20]);
 		int rogueCastingSpeed = rw.convertUnsignedByteToInt(bonusesAndFramesets[21]);
-		
+
 		int sorcDungeonIdleFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[22]);
 		int sorcAttackingFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[23]);
 		int sorcDungeonWalkFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[24]);
@@ -138,7 +138,7 @@ public class CharacterStore {
 		int sorcTownWalkFrameset = rw.convertUnsignedByteToInt(bonusesAndFramesets[30]);
 		int sorc1hAttackSpeed = rw.convertUnsignedByteToInt(bonusesAndFramesets[31]);
 		int sorcCastingSpeed = rw.convertUnsignedByteToInt(bonusesAndFramesets[32]);
-		
+
 		//Creating characters
 		char0 = new Character();
 		char0.setClassName("Warrior");
@@ -162,7 +162,7 @@ public class CharacterStore {
 		char0.setTownWalkFrameset(warriorTownWalkFrameset);
 		char0.setOneHandedAttackSpeed(warrior1hAttackSpeed);
 		char0.setCastingSpeed(warriorCastingSpeed);
-		
+
 		char1 = new Character();
 		char1.setClassName("Rogue");
 		char1.setInitStrength(initRogueStrength);
@@ -185,7 +185,7 @@ public class CharacterStore {
 		char1.setTownWalkFrameset(rogueTownWalkFrameset);
 		char1.setOneHandedAttackSpeed(rogue1hAttackSpeed);
 		char1.setCastingSpeed(rogueCastingSpeed);
-		
+
 		char2 = new Character();
 		char2.setClassName("Sorceror");
 		char2.setInitStrength(initSorcStrength);
@@ -208,12 +208,12 @@ public class CharacterStore {
 		char2.setTownWalkFrameset(sorcTownWalkFrameset);
 		char2.setOneHandedAttackSpeed(sorc1hAttackSpeed);
 		char2.setCastingSpeed(sorcCastingSpeed);
-		
+
 		characters.add(char0);
 		characters.add(char1);
 		characters.add(char2);
 	}
-	
+
 	private byte[] getInitStatBytes(){
 		byte[] startingStats = new byte[48];
 		long warriorInitStrength = char0.getInitStrength();
@@ -278,7 +278,7 @@ public class CharacterStore {
 		startingStats[47] = (byte)(sorcInitVit >>> 24);
 		return startingStats;
 	}
-	
+
 	private byte[] getMaxStatBytes(){
 		byte[] maxStats = new byte[48];
 		long warriorMaxStrength = char0.getMaxStrength();
@@ -343,7 +343,7 @@ public class CharacterStore {
 		maxStats[47] = (byte)(sorcMaxVit >>> 24);
 		return maxStats;
 	}
-	
+
 	private byte[] getBlockingBonusBytes(){
 		byte[] blockingBonuses = new byte[12];
 		long warriorBlockingBonus = char0.getBlockingBonus();
@@ -363,7 +363,7 @@ public class CharacterStore {
 		blockingBonuses[11] = (byte)(sorcBlockingBonus >>> 24);
 		return blockingBonuses;
 	}
-	
+
 	private byte[] getBonusesAndFramesetBytes(){
 		byte[] bonusesAndFramesets = new byte[33];
 		bonusesAndFramesets[0] = (byte) char0.getDungeonIdleFrameset();
@@ -401,13 +401,13 @@ public class CharacterStore {
 		bonusesAndFramesets[32] = (byte) char2.getCastingSpeed();
 		return bonusesAndFramesets;
 	}
-	
+
 	public void getCharactersAsBytes(){
 		byte[] retrievedInitStatBytes = this.getInitStatBytes();
 		byte[] retrievedMaxStatBytes = this.getMaxStatBytes();
 		byte[] retrievedBlockingBonusBytes = this.getBlockingBonusBytes();
 		byte[] retrievedBonusesAndFramesetBytes = this.getBonusesAndFramesetBytes();
-		
+
 		/*
 		System.out.println("ORIG: " + Arrays.toString(startingStats));
 		System.out.println("RETR: " + Arrays.toString(retrievedInitStatBytes));
@@ -431,16 +431,16 @@ public class CharacterStore {
 	}
 
 	public void writeCharactersToEXE() {
-		
+
 		byte[] retrievedInitStatBytes = this.getInitStatBytes();
 		rw.writeBytes(retrievedInitStatBytes, TomeOfKnowledge.MIN_STATS_OFFSET);
-		
+
 		byte[] retrievedMaxStatBytes = this.getMaxStatBytes();
 		rw.writeBytes(retrievedMaxStatBytes, TomeOfKnowledge.MAX_STATS_OFFSET);
-		
+
 		byte[] retrievedBlockingBonusBytes = this.getBlockingBonusBytes();
 		rw.writeBytes(retrievedBlockingBonusBytes, TomeOfKnowledge.BLOCKING_BONUSES_OFFSET);
-		
+
 		byte[] retrievedBonusesAndFramesetBytes = this.getBonusesAndFramesetBytes();
 		rw.writeBytes(retrievedBonusesAndFramesetBytes, TomeOfKnowledge.BONUSES_AND_FRAMESETS_OFFSET);
 	}
@@ -452,14 +452,14 @@ public class CharacterStore {
 	public List<Character> getCharacters() {
 		return characters;
 	}
-	
+
 	void setAllMaxStatsTo255() {
 		for(Character c : characters){
 			c.setMaxDexterity(255);
 			c.setMaxMagic(255);
 			c.setMaxStrength(255);
 			c.setMaxVitality(255);
-		}	
+		}
 	}
 
 	public void setCharZeroStartingSkillBySpellID(int i) {
@@ -492,7 +492,7 @@ public class CharacterStore {
 		rw.writeBytes(bytesToUse, TomeOfKnowledge.CHARACTER_ONE_SKILL_LOC_1);
 		rw.writeBytes(bytesToUse, TomeOfKnowledge.CHARACTER_ONE_SKILL_LOC_2);
 		rw.writeBytes(spellID, TomeOfKnowledge.CHARACTER_ONE_SPELL_LOC_1);
-		
+
 	}
 
 	public void setCharTwoStartingSkillBySpellID(int i) {

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/ItemModifier.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/ItemModifier.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 public class ItemModifier {
 
 	ReaderWriter rw = null;
-	
+
 	private long namePointer;
 	private String name;
 	private byte[] itemEffects;
@@ -20,21 +20,56 @@ public class ItemModifier {
 	private long maxGold;
 	private long valueMultiplier;
 	private byte[] itemBytes;
-	
+
 	public ItemModifier(byte[] readIn, ReaderWriter rw){
 		this.rw = rw;
 		namePointer = rw.convertFourBytesToOffset(readIn[0], readIn[1], readIn[2], readIn[3]);
 		BinEditHelper nf = new BinEditHelper();
 		name = nf.getNameUsingPointer(namePointer);
 		itemEffects = Arrays.copyOfRange(readIn, 4, 4+TomeOfKnowledge.NUMBER_OF_ITEM_EFFECTS);
+		// ### [ NOTE ] ###
+		//
+		// Each item effect has a dedicated minimum and maximum value. It would
+		// make sence to create a dedicated class (perhaps called ItemEffect)
+		// which contained the following three fields:
+		//
+		//    itemEffect
+		//    minimumEffectValue
+		//    maximumEffectValue
+		//
+		// The reason for creating a dedicated class for this, is that it is used
+		// by other parts of the game; e.g. UniqueItem contains the following:
+		//
+		//    private long effectOne;
+		//    private long minValueOne;
+		//    private long maxValueOne;
+		//    private long effectTwo;
+		//    private long minValueTwo;
+		//    private long maxValueTwo;
+		//    private long effectThree;
+		//    private long minValueThree;
+		//    private long maxValueThree;
+		//    private long effectFour;
+		//    private long minValueFour;
+		//    private long maxValueFour;
+		//    private long effectFive;
+		//    private long minValueFive;
+		//    private long maxValueFive;
+		//    private long effectSix;
+		//    private long minValueSix;
+		//    private long maxValueSix;
+		//
+		// TODO: Update the relevant code to reflect this.
+		//
+		// ### [/ NOTE ] ###
 		minimumEffectValue = rw.convertFourBytesToNumber(readIn[8], readIn[9], readIn[10], readIn[11]);
 		maximumEffectValue = rw.convertFourBytesToNumber(readIn[12], readIn[13], readIn[14], readIn[15]);
 		qualityLevel = rw.convertFourBytesToNumber(readIn[16], readIn[17], readIn[18], readIn[19]);
 		occurencePossibilities = String.format("%02X", readIn[22]) + String.format("%02X", readIn[21]) + String.format("%02X", readIn[20]);
 		byteTwentyThree = rw.convertUnsignedByteToInt(readIn[23]);
 		excludedComboIndicator = String.format("%02X", readIn[31]) + ";" + String.format("%02X", readIn[30]) +
-				";" + String.format("%02X", readIn[29]) + ";" + String.format("%02X", readIn[28]) + 
-				";" + String.format("%02X", readIn[27]) + ";" + String.format("%02X", readIn[26]) + 
+				";" + String.format("%02X", readIn[29]) + ";" + String.format("%02X", readIn[28]) +
+				";" + String.format("%02X", readIn[27]) + ";" + String.format("%02X", readIn[26]) +
 				";" + String.format("%02X", readIn[25]) + ";" + String.format("%02X", readIn[24]);
 		cursedIndicator = rw.convertFourBytesToNumber(readIn[32], readIn[33], readIn[34], readIn[35]);
 		minGold = rw.convertFourBytesToNumber(readIn[36], readIn[37], readIn[38], readIn[39]);
@@ -42,7 +77,7 @@ public class ItemModifier {
 		valueMultiplier = rw.convertFourBytesToNumber(readIn[44], readIn[45], readIn[46], readIn[47]);
 		itemBytes = readIn;
 	}
-	
+
 	public byte[] getModifierAsBytes(){
 		byte[] modifierAsBytes = new byte[48];
 		long namePointerRev = namePointer + TomeOfKnowledge.DIABLO_POINTERS_OFFSET;
@@ -98,14 +133,14 @@ public class ItemModifier {
 		modifierAsBytes[45] = (byte)(valueMultiplier >>> 8);
 		modifierAsBytes[46] = (byte)(valueMultiplier >>> 16);
 		modifierAsBytes[47] = (byte)(valueMultiplier >>> 24);
-		
+
 		//System.out.println("ORIG: " + Arrays.toString(itemBytes));
 		//System.out.println("BACK: " + Arrays.toString(modifierAsBytes));
 		//System.out.println();
-		
+
 		return modifierAsBytes;
 	}
-	
+
 	public void printModifier(){
 		System.out.println("Modifier name: " + name);
 		System.out.println("Modifier name pointer: " + namePointer);

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/ItemModifier.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/ItemModifier.java
@@ -220,14 +220,14 @@ public class ItemModifier {
 			"% steal life", //38
 			"damage/penetrate armor", //39
 			"attack speed (1=readiness, 4=haste)", //3A
-			"hit recovery (1=balance, 3=harmony", //3B
+			"hit recovery (1=balance, 3=harmony)", //3B
 			"fast block", //3C
 			"+ damage done", //3D
 			"random speed arrows", //3E
 			"x-y damage done (unusual item damage)", //3F
 			"altered durability", //40
 			"no strength requirements", //41
-			"spell-", //42
+			"spell charges", //42
 			"attack speed (1=readiness, 4=haste)", //43
 			"one handed", //44
 			"+200% damage versus demons", //45
@@ -236,11 +236,11 @@ public class ItemModifier {
 			"constantly lose life", //48
 			"0-12.5% steal life", //49
 			"infravision", //4A
-			"specified armor class", //4B
+			"positive armor class", //4B
 			"armor class added to life", //4C
 			"10% of mana added to armor class", //4D
 			"+30-clvl% resist fire", //4E
-			"armor class" //4F
+			"negative armor class" //4F
 		};
 		return itemEffects;
 	}

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/ItemModifiersStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/ItemModifiersStore.java
@@ -7,13 +7,13 @@ public class ItemModifiersStore {
 
 	ReaderWriter rw = null;
 	List<ItemModifier> itemModifiers = null;
-	
+
 	public ItemModifiersStore(ReaderWriter rw){
 		this.rw = rw;
 		itemModifiers = new ArrayList<ItemModifier>();
 		this.readInModifiers();
 	}
-	
+
 	public void readInModifiers(){
 		long pos = TomeOfKnowledge.MODIFIERS_OFFSET;
 		long spacing = TomeOfKnowledge.MODIFIER_LENGTH_IN_BYTES;
@@ -22,7 +22,7 @@ public class ItemModifiersStore {
 			pos = pos + spacing;
 		}
 	}
-	
+
 	private void readModifier(long position) {
 		long pos = position;
 		rw.seek(pos);
@@ -32,11 +32,11 @@ public class ItemModifiersStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		ItemModifier im = new ItemModifier(readIn, rw);
 		itemModifiers.add(im);
 	}
-	
+
 	public void printModifiers(){
 		for(ItemModifier im : itemModifiers){
 			im.printModifier();
@@ -53,6 +53,6 @@ public class ItemModifiersStore {
 			byte[] modifierAsBytes = this.getModifierAsBytes(i);
 			rw.writeBytes(modifierAsBytes, pos);
 			pos = pos + TomeOfKnowledge.MODIFIER_LENGTH_IN_BYTES;
-		}	
+		}
 	}
 }

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/MonsterAsBytes.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/MonsterAsBytes.java
@@ -4,16 +4,16 @@ public class MonsterAsBytes {
 
 	byte[] mainBytes;
 	byte enabledByte;
-	
+
 	public MonsterAsBytes(byte[] mainBytes, byte enabledByte){
 		this.mainBytes = mainBytes;
 		this.enabledByte = enabledByte;
 	}
-	
+
 	public byte[] getMainBytes(){
 		return mainBytes;
 	}
-	
+
 	public byte getEnabledByte(){
 		return enabledByte;
 	}

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/OpenDiabloEditor.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/OpenDiabloEditor.java
@@ -1,9 +1,9 @@
 package uk.me.karlsen.ode;
 
 public class OpenDiabloEditor {
-	
+
 	private ReaderWriter rw;
-	
+
 	QuestStore questStore;
 	SpellsStore spellStore;
 	ShrinesStore shrineStore;
@@ -13,20 +13,20 @@ public class OpenDiabloEditor {
 	BaseItemStore baseItemStore;
 	BaseMonsterStore baseMonsterStore;
 	UniqueMonsterStore uniqueMonsterStore;
-	
+
 	public static void main(String[] args){
 		OpenDiabloEditor dm = new OpenDiabloEditor();
 		dm.run();
 	}
 
 	public void run(){
-		
+
 		//####################################
 		//#      HERE WE READ IN DATA        #
 		//####################################
-		
+
 		rw = new ReaderWriter(false);
-		
+
 		questStore = new QuestStore(rw);
 		spellStore = new SpellsStore(rw);
 		shrineStore = new ShrinesStore(rw);
@@ -36,15 +36,15 @@ public class OpenDiabloEditor {
 		baseItemStore = new BaseItemStore(rw);
 		baseMonsterStore = new BaseMonsterStore(rw);
 		uniqueMonsterStore = new UniqueMonsterStore(rw);
-		
-		
+
+
 		//####################################
 		//# HERE WE SHOW YOU STUFF TO CHANGE #
 		//####################################
-		
-		
+
+
 		//Uncomment the ones you want to see when running the program...
-		
+
 		//questStore.printQuests();
 		//spellStore.printSpells();
 		//shrineStore.printShrines();
@@ -54,37 +54,37 @@ public class OpenDiabloEditor {
 		//baseItemStore.printItems();
 		baseMonsterStore.printMonsters();
 		//uniqueMonsterStore.printUniques();
-		
-		
+
+
 		//####################################
 		//# DO YOUR MODDING STUFF BELOW HERE #
 		//####################################
-		
+
 		//v1
 		//shrineStore.disableBadShrines();
-		
+
 		//v2
 		//characterStore.setAllMaxStatsTo255();
-		
+
 		//v3
 		//characterStore.setCharZeroStartingSkillBySpellID(2); //healing
 		//characterStore.setCharOneStartingSkillBySpellID(9); //infravision (inner sight)
 		//characterStore.setCharTwoStartingSkillBySpellID(5); //identify
-		
+
 		//v4
 		//fix or disable yellow zombies
 		//change name of infravision
 		//make healing skill mana drain
-		
+
 		//TODO
 		//promissory note
-		
+
 		//####################################
 		//# NOW WE WRITE TO DIABLO.EXE COPY  #
 		//####################################
-		
+
 		//writeAllData();
-	}	
+	}
 
 	private void writeAllData() {
 		shrineStore.writeShrinesToEXE();
@@ -96,5 +96,5 @@ public class OpenDiabloEditor {
 		baseItemStore.writeItemsToEXE();
 		baseMonsterStore.writeMonstersToEXE();
 		uniqueMonsterStore.writeMonstersToEXE();
-	}	
+	}
 }

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/Quest.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/Quest.java
@@ -10,61 +10,332 @@ public class Quest {
 			"Dark Passage",
 			"Unholy Altar"
 	};
-	
-	private int dungeonLevel;
-	private int byteOneValue;
-	private int byteTwoValue;
+
+	String[] dungeonTypes = {
+		"Cathedral", // 0
+		"Catacombs", // 1
+		"Cave",      // 2
+		"Hell"       // 3
+	}
+
+	String[] textEntries = {
+		// ### [ NOTE ] ###
+		//
+		// Crude copy of the text strings contained within the game.
+		//
+		// TODO: Add a copy of the original text strings which include proper
+		// punctuation, correct title casing and non-truncated words.
+		//
+		// ### [/ NOTE ] ###
+		"Ahh The Story Of Our King Is It? The Tragic Fall Of Leoric Wa",
+		"The Village Needs Your Help Good Master Some Months Ago King L",
+		"As I Told You Good Master The King Was Entombed Three Levels B",
+		"The Curse Of Our King Has Passed But I Fear That It Was Only Pa",
+		"The Loss Of His Son Was Too Much For King Leoric_ I Did What I C",
+		"I Don T Like To Think About How The King Died_ I Like To Remembe",
+		"I Made Many Of The Weapons And Most Of The Armor That King Leori",
+		"I Don T Care About That_ Listen No Skeleton Is Gonna Be My King",
+		"The Dead Who Walk Among The Living Follow The Cursed King_ He Ho",
+		"Look I M Running A Business Here_ I Don T Sell Information And",
+		"The Warmth Of Life Has Entered My Tomb_ Prepare Yourself Mortal",
+		"I See That This Strange Behavior Puzzles You As Well_ I Would Su",
+		"Master I Have A Strange Experience To Relate_ I Know That You H",
+		"Oh You Didn T Have To Bring Back My Sign But I Suppose That It",
+		"My Goodness Demons Running About The Village At Night Pillagin",
+		"Oh My Is That Where The Sign Went? My Grandmother And I Must Ha",
+		"Demons Stole Ogden S Sign You Say? That Doesn T Sound Much Like",
+		"You Know What I Think? Somebody Took That Sign And They Gonna W",
+		"No Mortal Can Truly Understand The Mind Of The Demon_ Never L",
+		"What Is He Saying I Took That? I Suppose That Griswold Is On H",
+		"Hey You That One That Kill All You Get Me Magic Banner Or We",
+		"You Kill Uglies Get Banner_ You Bring To Me Or Else___",
+		"You Give Yes Good Go Now We Strong_ We Kill All With Big Mag",
+		"This Does Not Bode Well For It Confirms My Darkest Fears_ While",
+		"You Must Hurry And Rescue Albrecht From The Hands Of Lazarus_ Th",
+		"Your Story Is Quite Grim My Friend_ Lazarus Will Surely Burn In",
+		"Lazarus Was The Archbishop Who Led Many Of The Townspeople Into",
+		"|",
+		"|",
+		"I Was Shocked When I Heard Of What The Townspeople Were Planning",
+		"I Remember Lazarus As Being A Very Kind And Giving Man_ He Spoke",
+		"I Was There When Lazarus Led Us Into The Labyrinth_ He Spoke Of",
+		"They Stab Then Bite Then They Re All Around You_ Liar Liar T",
+		"I Did Not Know This Lazarus Of Whom You Speak But I Do Sense A",
+		"Yes The Righteous Lazarus Who Was Sooo Effective Against Those",
+		"Abandon Your Foolish Quest_ All That Awaits You Is The Wrath Of",
+		"|",
+		"Hmm I Don T Know What I Can Really Tell You About This That Wil",
+		"I Have Always Tried To Keep A Large Supply Of Foodstuffs And Dri",
+		"I M Glad I Caught Up To You In Time Our Wells Have Become Brack",
+		"Please You Must Hurry_ Every Hour That Passes Brings Us Closer",
+		"What S That You Say The Mere Presence Of The Demons Had Caused",
+		"My Grandmother Is Very Weak And Garda Says That We Cannot Drink",
+		"Pepin Has Told You The Truth_ We Will Need Fresh Water Badly An",
+		"You Drink Water?",
+		"The People Of Tristram Will Die If You Cannot Restore Fresh Wate",
+		"For Once I M With You_ My Business Runs Dry So To Speak If",
+		"A Book That Speaks Of A Chamber Of Human Bones? Well A Chamber",
+		"I Am Afraid That I Don T Know Anything About That Good Master_",
+		"This Sounds Like A Very Dangerous Place_ If You Venture There P",
+		"I Am Afraid That I Haven T Heard Anything About That_ Perhaps Ca",
+		"I Know Nothing Of This Place But You May Try Asking Cain_ He Ta",
+		"Okay So Listen_ There S This Chamber Of Wood See_ And His Wife",
+		"You Will Become An Eternal Servant Of The Dark Lords Should You",
+		"A Vast And Mysterious Treasure You Say? Maybe I Could Be Intere",
+		"It Seems That The Archbishop Lazarus Goaded Many Of The Townsmen",
+		"Yes Farnham Has Mumbled Something About A Hulking Brute Who Wie",
+		"By The Light I Know Of This Vile Demon_ There Were Many That Bo",
+		"When Farnham Said Something About A Butcher Killing People I Im",
+		"I Saw What Farnham Calls The Butcher As It Swathed A Path Throug",
+		"Big Big Cleaver Killing All My Friends_ Couldn T Stop Him Had",
+		"The Butcher Is A Sadistic Creature That Delights In The Torture",
+		"I Know More Than You D Think About That Grisly Fiend_ His Little",
+		"Please Listen To Me_ The Archbishop Lazarus He Led Us Down Her",
+		"|",
+		"You Recite An Interesting Rhyme Written In A Style That Reminds",
+		"I Never Much Cared For Poetry_ Occasionally I Had Cause To Hire",
+		"This Does Seem Familiar Somehow_ I Seem To Recall Reading Somet",
+		"If You Have Questions About Blindness You Should Talk To Pepin_",
+		"I Am Afraid That I Have Neither Heard Nor Seen A Place That Matc",
+		"Look Here___ That S Pretty Funny Huh? Get It? Blind Look Here",
+		"This Is A Place Of Great Anguish And Terror And So Serves Its M",
+		"Lets See Am I Selling You Something? No_ Are You Giving Me Mone",
+		"You Claim To Have Spoken With Lachdanan? He Was A Great Hero Dur",
+		"You Speak Of A Brave Warrior Long Dead I Ll Have No Such Talk O",
+		"A Golden Elixir You Say_ I Have Never Concocted A Potion Of Tha",
+		"I Ve Never Heard Of A Lachdanan Before_ I M Sorry But I Don T T",
+		"If It Is Actually Lachdanan That You Have Met Then I Would Advi",
+		"Lachdanan Is Dead_ Everybody Knows That And You Can T Fool Me",
+		"You May Meet People Who Are Trapped Within The Labyrinth Such A",
+		"Wait Let Me Guess_ Cain Was Swallowed Up In A Gigantic Fissure",
+		"Please Don T Kill Me Just Hear Me Out_ I Was Once Captain Of K",
+		"You Have Not Found The Golden Elixir_ I Fear That I Am Doomed Fo",
+		"You Have Saved My Soul From Damnation And For That I Am In Your",
+		"Griswold Speaks Of The Anvil Of Fury A Legendary Artifact Long",
+		"Don T You Think That Griswold Would Be A Better Person To Ask Ab",
+		"If You Had Been Looking For Information On The Pestle Of Curing",
+		"Griswold S Father Used To Tell Some Of Us When We Were Growing U",
+		"Greetings It S Always A Pleasure To See One Of My Best Customer",
+		"Nothing Yet Eh? Well Keep Searching_ A Weapon Forged Upon The",
+		"I Can Hardly Believe It This Is The Anvil Of Fury Good Work",
+		"Griswold Can T Sell His Anvil_ What Will He Do Then? And I D Be",
+		"There Are Many Artifacts Within The Labyrinth That Hold Powers B",
+		"If You Were To Find This Artifact For Griswold It Could Put A S",
+		"The Gateway Of Blood And The Halls Of Fire Are Landmarks Of Myst",
+		"Every Child Hears The Story Of The Warrior Arkaine And His Mysti",
+		"Hmm___ It Sounds Like Something I Should Remember But I Ve Been",
+		"The Story Of The Magic Armor Called Valor Is Something I Often H",
+		"The Armor Known As Valor Could Be What Tips The Scales In Your F",
+		"Zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz___",
+		"Should You Find These Stones Of Blood Use Them Carefully_ Th",
+		"You Intend To Find The Armor Known As Valor? No One Has Ever",
+		"I Know Of Only One Legend That Speaks Of Such A Warrior As You D",
+		"I Am Afraid That I Haven T Heard Anything About Such A Vicious W",
+		"Cain Would Be Able To Tell You Much More About Something Like Th",
+		"If You Are To Battle Such A Fierce Opponent May Light Be Your G",
+		"Dark And Wicked Legends Surrounds The One Warlord Of Blood_ Be W",
+		"Always You Gotta Talk About Blood? What About Flowers And Sunsh",
+		"His Prowess With The Blade Is Awesome And He Has Lived For Thou",
+		"I Haven T Ever Dealt With This Warlord You Speak Of But He Soun",
+		"My Blade Sings For Your Blood Mortal And By My Dark Masters It",
+		"Griswold Speaks Of The Heaven Stone That Was Destined For The En",
+		"The Caravan Stopped Here To Take On Some Supplies For Their Jour",
+		"I Don T Know What It Is That They Thought They Could See With Th",
+		"Well A Caravan Of Some Very Important People Did Stop Here But",
+		"Stay For A Moment I Have A Story You Might Find Interesting_ A",
+		"I Am Still Waiting For You To Bring Me That Stone From The Heave",
+		"Let Me See That Aye___ Aye It Is As I Believed_ Give Me A Mom",
+		"I Used To Have A Nice Ring It Was A Really Expensive One With",
+		"The Heaven Stone Is Very Powerful And Were It Any But Griswold",
+		"If Anyone Can Make Something Out Of That Rock Griswold Can_ He",
+		"The Witch Adria Seeks A Black Mushroom? I Know As Much About Bla",
+		"Let Me Just Say This_ Both Garda And I Would Never Ever Serve B",
+		"The Witch Told Me That You Were Searching For The Brain Of A Dem",
+		"Excellent This Is Just What I Had In Mind_ I Was Able To Finish",
+		"I Think Ogden Might Have Some Mushrooms In The Storage Cellar_ W",
+		"If Adria Doesn T Have One Of These You Can Bet That S A Rare Th",
+		"Ogden Mixes A Mean Black Mushroom But I Get Sick If I Drink Tha",
+		"What Do We Have Here? Interesting It Looks Like A Book Of Reage",
+		"It S A Big Black Mushroom That I Need_ Now Run Off And Get It F",
+		"Yes This Will Be Perfect For A Brew That I Am Creating_ By The",
+		"Why Have You Brought That Here? I Have No Need For A Demon S Bra",
+		"What? Now You Bring Me That Elixir From The Healer? I Was Able T",
+		"I Don T Have Any Mushrooms Of Any Size Or Color For Sale_ How Ab",
+		"So The Legend Of The Map Is Real_ Even I Never Truly Believed A",
+		"Our Time Is Running Short I Sense His Dark Power Building And O",
+		"I Am Sure That You Tried Your Best But I Fear That Even Your St",
+		"If The Witch Can T Help You And Suggests You See Cain What Make",
+		"I Can T Make Much Of The Writing On This Map But Perhaps Adria",
+		"The Best Person To Ask About That Sort Of Thing Would Be Our Sto",
+		"I Have Never Seen A Map Of This Sort Before_ Where D You Get It?",
+		"Listen Here Come Close_ I Don T Know If You Know What I Know B",
+		"Oh I M Afraid This Does Not Bode Well At All_ This Map Of The S",
+		"I Ve Been Looking For A Map But That Certainly Isn T It_ You Sh",
+		"Pleeeease No Hurt_ No Kill_ Keep Alive And Next Time Good Bring",
+		"Something For You I Am Making_ Again Not Kill Gharbad_ Live And",
+		"Nothing Yet Almost Done_ Very Powerful Very Strong_ Live L",
+		"This Too Good For You_ Very Powerful You Want You Take",
+		"What? Why Are You Here? All These Interruptions Are Enough To M",
+		"Arrrrgh Your Curiosity Will Be The Death Of You",
+		"Hello My Friend_ Stay Awhile And Listen___",
+		"While You Are Venturing Deeper Into The Labyrinth You May Find T",
+		"I Know Of Many Myths And Legends That May Contain Answers To Que",
+		"Griswold A Man Of Great Action And Great Courage_ I Bet He Nev",
+		"Ogden Has Owned And Run The Rising Sun Inn And Tavern For Almost",
+		"Poor Farnham_ He Is A Disquieting Reminder Of The Doomed Assembl",
+		"The Witch Adria Is An Anomaly Here In Tristram_ She Arrived Sh",
+		"The Story Of Wirt Is A Frightening And Tragic One_ He Was Taken",
+		"Ah Pepin_ I Count Him As A True Friend Perhaps The Closest I",
+		"Gillian Is A Fine Woman_ Much Adored For Her High Spirits And He",
+		"Greetings Good Master_ Welcome To The Tavern Of The Rising Sun",
+		"Many Adventurers Have Graced The Tables Of My Tavern And Ten Ti",
+		"Griswold The Blacksmith Is Extremely Knowledgeable About Weapons",
+		"Farnham Spends Far Too Much Time Here Drowning His Sorrows In C",
+		"Adria Is Wise Beyond Her Years But I Must Admit She Frightens",
+		"If You Want To Know More About The History Of Our Village The S",
+		"Wirt Is A Rapscallion And A Little Scoundrel_ He Was Always Gett",
+		"Pepin Is A Good Man And Certainly The Most Generous In The Vil",
+		"Gillian My Barmaid? If It Were Not For Her Sense Of Duty To Her",
+		"What Ails You My Friend?",
+		"I Have Made A Very Interesting Discovery_ Unlike Us The Creatur",
+		"Before It Was Taken Over By Well Whatever Lurks Below The Cat",
+		"Griswold Knows As Much About The Art Of War As I Do About The Ar",
+		"Cain Is A True Friend And A Wise Sage_ He Maintains A Vast Libra",
+		"Even My Skills Have Been Unable To Fully Heal Farnham_ Oh I Hav",
+		"While I Use Some Limited Forms Of Magic To Create The Potions An",
+		"Poor Wirt_ I Did All That Was Possible For The Child But I Know",
+		"I Really Don T Understand Why Ogden Stays Here In Tristram_ He S",
+		"Ogden S Barmaid Is A Sweet Girl_ Her Grandmother Is Quite Ill A",
+		"Good Day How May I Serve You?",
+		"My Grandmother Had A Dream That You Would Come And Talk To Me_ S",
+		"The Woman At The Edge Of Town Is A Witch She Seems Nice Enough",
+		"Our Blacksmith Is A Point Of Pride To The People Of Tristram_ No",
+		"Cain Has Been The Storyteller Of Tristram For As Long As I Can R",
+		"Farnham Is A Drunkard Who Fills His Belly With Ale And Everyone",
+		"Pepin Saved My Grandmother S Life And I Know That I Can Never R",
+		"I Grew Up With Wirt S Mother Canace_ Although She Was Only Slig",
+		"Ogden And His Wife Have Taken Me And My Grandmother Into Their H",
+		"Well What Can I Do For Ya?",
+		"If You Re Looking For A Good Weapon Let Me Show This To You_ Ta",
+		"The Axe? Aye That S A Good Weapon Balanced Against Any Foe_ Lo",
+		"Look At That Edge That Balance_ A Sword In The Right Hands And",
+		"Your Weapons And Armor Will Show The Signs Of Your Struggles Aga",
+		"While I Have To Practically Smuggle In The Metals And Tools I Ne",
+		"Gillian Is A Nice Lass_ Shame That Her Gammer Is In Such Poor He",
+		"Sometimes I Think That Cain Talks Too Much But I Guess That Is",
+		"I Was With Farnham That Night That Lazarus Led Us Into Labyrinth",
+		"A Good Man Who Puts The Needs Of Others Above His Own_ You Won T",
+		"That Lad Is Going To Get Himself Into Serious Trouble___ Or I Gu",
+		"The Innkeeper Has Little Business And No Real Way Of Turning A P",
+		"Can T A Fella Drink In Peace?",
+		"The Gal Who Brings The Drinks? Oh Yeah What A Pretty Lady_ So",
+		"Why Don T That Old Crone Do Somethin For A Change_ Sure Sure",
+		"Cain Isn T What He Says He Is_ Sure Sure He Talks A Good Story",
+		"Griswold? Good Old Griswold_ I Love Him Like A Brother We Fough",
+		"Hehehe I Like Pepin_ He Really Tries You Know_ Listen Here Yo",
+		"Wirt Is A Kid With More Problems Than Even Me And I Know All Ab",
+		"Ogden Is The Best Man In Town_ I Don T Think His Wife Likes Me M",
+		"I Wanna Tell Ya Sumthin Cause I Know All About This Stuff_ It",
+		"No One Ever Lis___ Listens To Me_ Somewhere I Ain T Too Sure",
+		"I Know You Gots Your Own Ideas And I Know You Re Not Gonna Beli",
+		"If I Was You___ And I Ain T___ But If I Was I D Sell All That S",
+		"I Sense A Soul In Search Of Answers___",
+		"Wisdom Is Earned Not Given_ If You Discover A Tome Of Knowledge",
+		"The Greatest Power Is Often The Shortest Lived_ You May Find Anc",
+		"Though The Heat Of The Sun Is Beyond Measure The Mere Flame Of",
+		"The Sum Of Our Knowledge Is In The Sum Of Its People_ Should You",
+		"To A Man Who Only Knows Iron There Is No Greater Magic Than Ste",
+		"Corruption Has The Strength Of Deceit But Innocence Holds The P",
+		"A Chest Opened In Darkness Holds No Greater Treasure Than When I",
+		"The Higher You Place Your Faith In One Man The Farther It Has T",
+		"The Hand The Heart And The Mind Can Perform Miracles When They",
+		"There Is Much About The Future We Cannot See But When It Comes",
+		"Earthen Walls And Thatched Canopy Do Not A Home Create_ The Innk",
+		"Pssst___ Over Here___",
+		"Not Everyone In Tristram Has A Use Or A Market For Everythin",
+		"Don T Trust Everything The Drunk Says_ Too Many Ales Have Fogged",
+		"In Case You Haven T Noticed I Don T Buy Anything From Tristram_",
+		"I Guess I Owe The Blacksmith My Life What There Is Of It_ Sure",
+		"If I Were A Few Years Older I Would Shower Her With Whatever Ri",
+		"Cain Knows Too Much_ He Scares The Life Out Of Me Even More Th",
+		"Farnham Now There Is A Man With Serious Problems And I Know A",
+		"As Long As You Don T Need Anything Reattached Old Pepin Is As G",
+		"Adria Truly Bothers Me_ Sure Cain Is Creepy In What He Can Tell",
+		"Ogden Is A Fool For Staying Here_ I Could Get Him Out Of Town Fo",
+		"Beyond The Hall Of Heroes Lies The Chamber Of Bone_ Eternal Deat",
+		"___and So Locked Beyond The Gateway Of Blood And Past The Hall",
+		"I Can See What You See Not_ Vision Milky Then Eyes Rot_ When You",
+		"The Armories Of Hell Are Home To The Warlord Of Blood_ In His Wa",
+		"Beyond The Hall Of Heroes Lies The Chamber Of Bone_ Eternal Deat",
+		"___and So Locked Beyond The Gateway Of Blood And Past The Hall",
+		"I Can See What You See Not_ Vision Milky Then Eyes Rot_ When You",
+		"The Armories Of Hell Are Home To The Warlord Of Blood_ In His Wa",
+		"Beyond The Hall Of Heroes Lies The Chamber Of Bone_ Eternal Deat",
+		"___and So Locked Beyond The Gateway Of Blood And Past The Hall",
+		"I Can See What You See Not_ Vision Milky Then Eyes Rot_ When You",
+		"The Armories Of Hell Are Home To The Warlord Of Blood_ In His Wa",
+		"|",
+		"|",
+		"Take Heed And Bear Witness To The Truths That Lie Herein For Th",
+		"Take Heed And Bear Witness To The Truths That Lie Herein For Th_0",
+		"Take Heed And Bear Witness To The Truths That Lie Herein For Th_1",
+		"So It Came To Be That There Was A Great Revolution Within The Bu",
+		"Many Demons Traveled To The Mortal Realm In Search Of The Three",
+		"So It Came To Be That The Three Prime Evils Were Banished In Spi",
+		"All Praises To Diablo Lord Of Terror And Survivor Of The Dark",
+		"Glory And Approbation To Diablo Lord Of Terror And Leader Of T",
+		"Hail And Sacrifice To Diablo Lord Of Terror And Destroyer Of S",
+		"Thank Goodness You Ve Returned Much Has Changed Since You Lived"
+	}
+
+	private int dungeonLevelSingle;
+	private int dungeonLevelMulti;
+	private int dungeonType;
 	private int questNumber;
 	private int byteFourValue;
 	private int specialLevel; //SP only
 	private int zeroOne;
 	private int zeroTwo;
 	private long mpTriggerFlag;
-	private int byteElevenValue;
-	private int byteTwelveValue;
-	private int byteThirteenValue;
-	private int byteFourteenValue;
+	private long textEntryIDX;
 	private byte[] questBytes;
 	int slotNumber;
-	
+
 	public Quest(int indexValue, byte[] questBytes, ReaderWriter rw){
 		this.slotNumber = indexValue;
-		dungeonLevel = rw.convertUnsignedByteToInt(questBytes[0]);
-		byteOneValue = rw.convertUnsignedByteToInt(questBytes[1]);
-		byteTwoValue = rw.convertUnsignedByteToInt(questBytes[2]);
+		dungeonLevelSingle = rw.convertUnsignedByteToInt(questBytes[0]);
+		dungeonLevelMulti = rw.convertUnsignedByteToInt(questBytes[1]);
+		dungeonType = rw.convertUnsignedByteToInt(questBytes[2]);
 		questNumber = rw.convertUnsignedByteToInt(questBytes[3]);
 		byteFourValue = rw.convertUnsignedByteToInt(questBytes[4]);
 		specialLevel = rw.convertUnsignedByteToInt(questBytes[5]); //SP only
 		zeroOne = rw.convertUnsignedByteToInt(questBytes[6]);
 		zeroTwo = rw.convertUnsignedByteToInt(questBytes[7]);
 		mpTriggerFlag = rw.convertFourBytesToNumber(questBytes[8], questBytes[9], questBytes[10], questBytes[11]);
-		byteElevenValue = rw.convertUnsignedByteToInt(questBytes[12]);
-		byteTwelveValue = rw.convertUnsignedByteToInt(questBytes[13]);
-		byteThirteenValue = rw.convertUnsignedByteToInt(questBytes[14]);
-		byteFourteenValue = rw.convertUnsignedByteToInt(questBytes[15]);
+		textEntryIDX = rw.convertFourBytesToNumber(questBytes[12], questBytes[13], questBytes[14], questBytes[15]);
 		this.questBytes = questBytes;
 	}
-	
+
 	public void printQuest(){
 		System.out.println("Slot number: " + slotNumber + " (hex: " + Integer.toHexString(slotNumber) + ")");
-		System.out.println("Dungeon level: " + dungeonLevel);
-		System.out.println("Unknown: " + byteOneValue);
-		System.out.println("Unknown: " + byteTwoValue);
+		System.out.println("Dungeon level single: " + dungeonLevelSingle);
+		System.out.println("Dungeon level multi: " + dungeonLevelMulti);
+		System.out.println("Dungeon type: " + dungeonTypes[dungeonType]);
 		System.out.println("Quest number: " + questNumber);
 		System.out.println("Unknown: " + byteFourValue);
 		System.out.println("Special level: " + specialLevels[specialLevel]);
 		System.out.println("Zero: " + zeroOne);
 		System.out.println("Zero: " + zeroTwo);
 		System.out.println("Multi player trigger flag: " + mpTriggerFlag);
-		System.out.println("Unknown: " + byteFourteenValue + ", " + byteThirteenValue + ", " + byteTwelveValue + ", " + byteElevenValue);
+		System.out.println("Text entry IDX: `" + textEntries[textEntryIDX] + "`");
 		System.out.println();
 	}
 
 	public byte[] getQuestAsBytes() {
 		byte[] questAsBytes = new byte[16];
-		questAsBytes[0] = (byte) dungeonLevel;
-		questAsBytes[1] = (byte) byteOneValue;
-		questAsBytes[2] = (byte) byteTwoValue;
+		questAsBytes[0] = (byte) dungeonLevelSingle;
+		questAsBytes[1] = (byte) dungeonLevelMulti;
+		questAsBytes[2] = (byte) dungeonType;
 		questAsBytes[3] = (byte) questNumber;
 		questAsBytes[4] = (byte) byteFourValue;
 		questAsBytes[5] = (byte) specialLevel;
@@ -74,40 +345,39 @@ public class Quest {
 		questAsBytes[9] = (byte) (mpTriggerFlag >>>  8);;
 		questAsBytes[10] = (byte) (mpTriggerFlag >>>  16);;
 		questAsBytes[11] = (byte) (mpTriggerFlag >>>  24);;
-		questAsBytes[12] = (byte) byteElevenValue;
-		questAsBytes[13] = (byte) byteTwelveValue;
-		questAsBytes[14] = (byte) byteThirteenValue;
-		questAsBytes[15] = (byte) byteFourteenValue;
-		
+		questAsBytes[12] = (byte) (textEntryIDX >>>  0);;
+		questAsBytes[13] = (byte) (textEntryIDX >>>  8);;
+		questAsBytes[14] = (byte) (textEntryIDX >>>  16);;
+		questAsBytes[15] = (byte) (textEntryIDX >>>  24);;
 		//System.out.println("ORIG: " + Arrays.toString(questBytes));
 		//System.out.println("BACK: " + Arrays.toString(questAsBytes));
 		//System.out.println();
-		
+
 		return questAsBytes;
 	}
 
-	public int getDungeonLevel() {
-		return dungeonLevel;
+	public int getDungeonLevelSingle() {
+		return dungeonLevelSingle;
 	}
 
-	public void setDungeonLevel(int dungeonLevel) {
-		this.dungeonLevel = dungeonLevel;
+	public void setDungeonLevelSingle(int dungeonLevelSingle) {
+		this.dungeonLevelSingle = dungeonLevelSingle;
 	}
 
-	public int getByteOneValue() {
-		return byteOneValue;
+	public int getDungeonLevelMulti() {
+		return dungeonLevelMulti;
 	}
 
-	public void setByteOneValue(int byteOneValue) {
-		this.byteOneValue = byteOneValue;
+	public void setDungeonLevelMulti(int dungeonLevelMulti) {
+		this.dungeonLevelMulti = dungeonLevelMulti;
 	}
 
-	public int getByteTwoValue() {
-		return byteTwoValue;
+	public int getDungeonType() {
+		return dungeonType;
 	}
 
-	public void setByteTwoValue(int byteTwoValue) {
-		this.byteTwoValue = byteTwoValue;
+	public void setDungeonType(int dungeonType) {
+		this.dungeonType = dungeonType;
 	}
 
 	public int getQuestNumber() {
@@ -158,36 +428,12 @@ public class Quest {
 		this.mpTriggerFlag = mpTriggerFlag;
 	}
 
-	public int getByteElevenValue() {
-		return byteElevenValue;
+	public long getTextEntryIDX() {
+		return textEntryIDX;
 	}
 
-	public void setByteElevenValue(int byteElevenValue) {
-		this.byteElevenValue = byteElevenValue;
-	}
-
-	public int getByteTwelveValue() {
-		return byteTwelveValue;
-	}
-
-	public void setByteTwelveValue(int byteTwelveValue) {
-		this.byteTwelveValue = byteTwelveValue;
-	}
-
-	public int getByteThirteenValue() {
-		return byteThirteenValue;
-	}
-
-	public void setByteThirteenValue(int byteThirteenValue) {
-		this.byteThirteenValue = byteThirteenValue;
-	}
-
-	public int getByteFourteenValue() {
-		return byteFourteenValue;
-	}
-
-	public void setByteFourteenValue(int byteFourteenValue) {
-		this.byteFourteenValue = byteFourteenValue;
+	public void setTextEntryIDX(long textEntryIDX) {
+		this.textEntryIDX = textEntryIDX;
 	}
 
 	public byte[] getQuestBytes() {

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/Quest.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/Quest.java
@@ -12,10 +12,12 @@ public class Quest {
 	};
 
 	String[] dungeonTypes = {
-		"Cathedral", // 0
-		"Catacombs", // 1
-		"Cave",      // 2
-		"Hell"       // 3
+		"Tristram",  // 0
+		"Cathedral", // 1
+		"Catacombs", // 2
+		"Caves",     // 3
+		"Hell"       // 4
+		             // -1 (0xFF) = "None"
 	}
 
 	String[] textEntries = {
@@ -320,7 +322,9 @@ public class Quest {
 		System.out.println("Slot number: " + slotNumber + " (hex: " + Integer.toHexString(slotNumber) + ")");
 		System.out.println("Dungeon level single: " + dungeonLevelSingle);
 		System.out.println("Dungeon level multi: " + dungeonLevelMulti);
-		System.out.println("Dungeon type: " + dungeonTypes[dungeonType]);
+		if(dungeonType >= 0 && dungeonType <= 4){
+			System.out.println("Dungeon type: " + dungeonTypes[dungeonType]);
+		}
 		System.out.println("Quest number: " + questNumber);
 		System.out.println("Unknown: " + byteFourValue);
 		System.out.println("Special level: " + specialLevels[specialLevel]);

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/Quest.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/Quest.java
@@ -18,7 +18,7 @@ public class Quest {
 		"Caves",     // 3
 		"Hell"       // 4
 		             // -1 (0xFF) = "None"
-	}
+	};
 
 	String[] textEntries = {
 		// ### [ NOTE ] ###
@@ -288,7 +288,7 @@ public class Quest {
 		"Glory And Approbation To Diablo Lord Of Terror And Leader Of T",
 		"Hail And Sacrifice To Diablo Lord Of Terror And Destroyer Of S",
 		"Thank Goodness You Ve Returned Much Has Changed Since You Lived"
-	}
+	};
 
 	private int dungeonLevelSingle;
 	private int dungeonLevelMulti;
@@ -331,7 +331,7 @@ public class Quest {
 		System.out.println("Zero: " + zeroOne);
 		System.out.println("Zero: " + zeroTwo);
 		System.out.println("Multi player trigger flag: " + mpTriggerFlag);
-		System.out.println("Text entry IDX: `" + textEntries[textEntryIDX] + "`");
+		System.out.println("Text entry IDX: `" + textEntries[(int) textEntryIDX] + "`");
 		System.out.println();
 	}
 

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/QuestStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/QuestStore.java
@@ -7,13 +7,13 @@ public class QuestStore {
 
 	ReaderWriter rw = null;
 	List<Quest> quests = null;
-	
+
 	public QuestStore(ReaderWriter rw){
 		this.rw = rw;
 		quests = new ArrayList<Quest>();
 		this.readInQuests();
 	}
-	
+
 	public void readInQuests(){
 		//seek and read
 		long pos = TomeOfKnowledge.QUESTS_OFFSET; //quests
@@ -23,28 +23,30 @@ public class QuestStore {
 			pos = pos + spacing;
 		}
 	}
-	
+
 	/*
 	 * 0 	SP dungeon level the quest appears in.
 1 	MP dungeon level the quest appears in.
-2 	Unknown
-All have FF here, except those with a value at byte 5...
+2 	Dungeon type (Cathedral, catacombs, caves, hell)
+   All have FF here ("None"), except those with a value at byte 5...
 3 	Quest number
 4 	Don't know....
 5 	Special level setting (SP only)
-01 = King Leoric's Tomb
-02 = The Chamber of Bone
-03 = Maze
-For some odd reason, the Ogden's Sign quest, which uses this,
-does not have this value at this location.
-4 = Dark Passage
-5 = Unholy Altar
+   01 = King Leoric's Tomb
+   02 = The Chamber of Bone
+   03 = Maze
+   For some odd reason, the Ogden's Sign quest, which uses this,
+   does not have this value at this location.
+   04 = Dark Passage
+   05 = Unholy Altar
 6-7 	Always zero
 >8-11 	MultiPlayer trigger flag
-00 = SP only quest
-01 = SP and MP quest
-12-15 	Unknown.....
-	 */
+   00 = SP only quest
+   01 = SP and MP quest
+12-15 	Text entry IDX
+   00 = "Ahh, the story of our King, is it?"
+   01 = "The village needs your help, good master!"
+	*/
 	public void readQuest(int slot, long position){
 		long pos = position;
 		rw.seek(position);
@@ -55,11 +57,11 @@ does not have this value at this location.
 			rw.seek(pos);
 			readIn[i] = rw.readByte();
 		}
-		
+
 		Quest q = new Quest(slot, readIn, rw);
 		quests.add(q);
 	}
-	
+
 	public void printQuests(){
 		for(Quest q : quests){
 			q.printQuest();

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/ReaderWriter.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/ReaderWriter.java
@@ -11,7 +11,7 @@ import java.nio.channels.FileChannel;
 public class ReaderWriter {
 
 	RandomAccessFile raf = null;
-	
+
 	public ReaderWriter(boolean readOnly){
 		if(readOnly){
 			File f = new File("input/Diablo.exe");
@@ -22,7 +22,7 @@ public class ReaderWriter {
 				System.exit(-1);
 			}
 		} else {
-			
+
 		}
 			File f = new File("input/Diablo.exe");
 			File newFile = this.createNewFile(f);
@@ -33,7 +33,7 @@ public class ReaderWriter {
 				System.exit(-1);
 			}
 	}
-	
+
 	private File createNewFile(File originalFile) {
 		FileInputStream fis = null;
 		try {
@@ -84,7 +84,7 @@ public class ReaderWriter {
 			System.exit(-1);
 		}
 	}
-	
+
 	public int read(){
 		int read = -1;
 		try {
@@ -95,7 +95,7 @@ public class ReaderWriter {
 		}
 		return read;
 	}
-	
+
 	public byte readByte(){
 		byte read = -1;
 		try {
@@ -106,7 +106,7 @@ public class ReaderWriter {
 		}
 		return read;
 	}
-	
+
 	public byte[] readBytes(int numBytes){
 		byte[] bytes = new byte[numBytes];
 		try {
@@ -117,7 +117,7 @@ public class ReaderWriter {
 		}
 		return bytes;
 	}
-	
+
 	public void writeBytes(byte[] bytes, long pos){
 		try {
 			raf.seek(pos);
@@ -127,7 +127,7 @@ public class ReaderWriter {
 			System.exit(-1);
 		}
 	}
-	
+
 	public void writeOneByteMultipleTimes(byte oneByte, long pos, int numBytes){
 		try {
 			raf.seek(pos);
@@ -142,7 +142,7 @@ public class ReaderWriter {
 			System.exit(-1);
 		}
 	}
-	
+
 	public void writeByte(byte byteValue, long pos){
 		try {
 			raf.seek(pos);
@@ -152,7 +152,7 @@ public class ReaderWriter {
 			System.exit(-1);
 		}
 	}
-	
+
 	//FIXME -- this should not exist
 	public long convertThreeBytesToOffset(int... fourBytes){
 		String byte0 = Integer.toHexString(fourBytes[3] & 0xFF);
@@ -175,7 +175,7 @@ public class ReaderWriter {
 		long value = Long.parseLong(str, 16) - TomeOfKnowledge.DIABLO_POINTERS_OFFSET;
 		return value;
 	}
-	
+
 	//FIXME -- move to BinEditHelper
 	public long convertFourBytesToNumber(int... bytes){
 		String byte0 = Integer.toHexString(bytes[3] & 0xFF);
@@ -198,7 +198,7 @@ public class ReaderWriter {
 		long value = Long.parseLong(str, 16);
 		return value;
 	}
-	
+
 	//FIXME -- move to BinEditHelper
 	public long convertFourBytesToNumber(byte[] holdingArray, int offset){
 		String byte0 = Integer.toHexString(holdingArray[offset+3] & 0xFF);
@@ -221,7 +221,7 @@ public class ReaderWriter {
 		long value = Long.parseLong(str, 16);
 		return value;
 	}
-	
+
 	//FIXME -- move to BinEditHelper
 	public int convertTwoBytesToInt(int... bytes){
 		int value = -1;
@@ -237,7 +237,7 @@ public class ReaderWriter {
 		value = Integer.parseInt(str, 16);
 		return value;
 	}
-	
+
 	//FIXME -- move to BinEditHelper
 	public long convertFourBytesToOffset(int... fourBytes){
 		long value = -1;
@@ -262,7 +262,7 @@ public class ReaderWriter {
 		value = value - TomeOfKnowledge.DIABLO_POINTERS_OFFSET;
 		return value;
 	}
-	
+
 	//FIXME -- move to BinEditHelper
 	public int convertUnsignedByteToInt(byte b){
 		return (int) b & 0xFF;

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/Shrine.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/Shrine.java
@@ -9,7 +9,7 @@ public class Shrine {
 	private int gameTypesInWhichPresent;
 	private int shrineIndex;
 	boolean modifiedFromDefault;
-	
+
 	public Shrine(int shrineIndex, String shrineName, long shrinePointer, int minShrineLevel, int maxShrineLevel, int gameTypesInWhichPresent){
 		this.shrineIndex = shrineIndex;
 		this.shrineName = shrineName;
@@ -19,7 +19,7 @@ public class Shrine {
 		this.gameTypesInWhichPresent = gameTypesInWhichPresent;
 		this.modifiedFromDefault = false;
 	}
-	
+
 	public void printShrine() {
 		System.out.println("Shrine index: " + shrineIndex);
 		System.out.println("Shrine name: " + shrineName);
@@ -43,7 +43,7 @@ public class Shrine {
 	public byte getMinShrineLevelByte() {
 		return (byte) minShrineLevel;
 	}
-	
+
 	public byte getMaxShrineLevelByte() {
 		return (byte) maxShrineLevel;
 	}
@@ -56,7 +56,7 @@ public class Shrine {
 		minShrineLevel = i;
 		modifiedFromDefault = true;
 	}
-	
+
 	public void setMaxShrineLevel(int i) {
 		maxShrineLevel = i;
 		modifiedFromDefault = true;

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/ShrinesAsBytes.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/ShrinesAsBytes.java
@@ -6,7 +6,7 @@ public class ShrinesAsBytes {
 	byte[] minShrineLevelBytes = new byte[TomeOfKnowledge.NUMBER_OF_SHRINES];
 	byte[] maxShrineLevelBytes = new byte[TomeOfKnowledge.NUMBER_OF_SHRINES];
 	byte[] gameTypesInWhichPresentBytes = new byte[TomeOfKnowledge.NUMBER_OF_SHRINES];
-	
+
 	public ShrinesAsBytes(byte[] shrinePointerBytes,
 			byte[] minShrineLevelBytes, byte[] maxShrineLevelBytes,
 			byte[] gameTypesInWhichPresentBytes) {

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/ShrinesStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/ShrinesStore.java
@@ -8,25 +8,25 @@ public class ShrinesStore {
 
 	ReaderWriter rw = null;
 	private List<Shrine> shrines = null;
-	
+
 	byte[] origShrinePointerBytes;
 	byte[] origMinShrineLevelBytes;
 	byte[] origMaxShrineLevelBytes;
 	byte[] origGameTypesInWhichPresentBytes;
-	
+
 	public ShrinesStore(ReaderWriter rw){
 		this.rw = rw;
 		shrines = new ArrayList<Shrine>();
 		this.readInShrines();
 	}
-	
+
 	public void readInShrines(){
-		
+
 		long[] shrinePointers = new long[TomeOfKnowledge.NUMBER_OF_SHRINES];
 		int[] minShrineLevels = new int[TomeOfKnowledge.NUMBER_OF_SHRINES];
 		int[] maxShrineLevels = new int[TomeOfKnowledge.NUMBER_OF_SHRINES];
 		int[] gameTypesInWhichPresent = new int[TomeOfKnowledge.NUMBER_OF_SHRINES];
-		
+
 		long pos = TomeOfKnowledge.SHRINE_POINTERS_OFFSET;
 		rw.seek(pos);
 		origShrinePointerBytes = rw.readBytes(TomeOfKnowledge.NUMBER_OF_SHRINES*4);
@@ -40,9 +40,9 @@ public class ShrinesStore {
 			}
 			shrinePointers[i] = rw.convertThreeBytesToOffset(pointer);
 		}
-		
+
 		System.out.println();
-		
+
 		pos = TomeOfKnowledge.SHRINE_MIN_LEVELS_OFFSET;
 		rw.seek(pos);
 		origMinShrineLevelBytes = rw.readBytes(TomeOfKnowledge.NUMBER_OF_SHRINES);
@@ -52,9 +52,9 @@ public class ShrinesStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		System.out.println();
-		
+
 		pos = TomeOfKnowledge.SHRINE_MAX_LEVELS_OFFSET;
 		rw.seek(pos);
 		origMaxShrineLevelBytes = rw.readBytes(TomeOfKnowledge.NUMBER_OF_SHRINES);
@@ -64,7 +64,7 @@ public class ShrinesStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		System.out.println();
 		pos = TomeOfKnowledge.SHRINE_GAME_TYPE_OFFSET;
 		rw.seek(pos);
@@ -75,7 +75,7 @@ public class ShrinesStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		//create Shrine objects and add to list
 		for(int i = 0; i < TomeOfKnowledge.NUMBER_OF_SHRINES; i++){
 			BinEditHelper h = new BinEditHelper();
@@ -96,7 +96,7 @@ public class ShrinesStore {
 		byte[] minShrineLevelBytes = this.getMinShrineLevelBytes();
 		byte[] maxShrineLevelBytes = this.getMaxShrineLevelBytes();
 		byte[] gameTypesInWhichPresentBytes = this.getGameTypesInWhichPresentBytes();
-		
+
 		/*
 		System.out.println("ORIG: " + Arrays.toString(origShrinePointerBytes));
 		System.out.println("BACK: " + Arrays.toString(shrinePointerBytes));
@@ -111,11 +111,11 @@ public class ShrinesStore {
 		System.out.println("BACK: " + Arrays.toString(gameTypesInWhichPresentBytes));
 		System.out.println();
 		*/
-		
+
 		ShrinesAsBytes sab = new ShrinesAsBytes(shrinePointerBytes, minShrineLevelBytes, maxShrineLevelBytes, gameTypesInWhichPresentBytes);
 		return sab;
 	}
-	
+
 	private byte[] getShrinePointerBytes(){
 		byte[] shrinePointerBytes = new byte[TomeOfKnowledge.NUMBER_OF_SHRINES*4];
 		int location = 0;
@@ -127,7 +127,7 @@ public class ShrinesStore {
 		}
 		return shrinePointerBytes;
 	}
-	
+
 	private byte[] getMinShrineLevelBytes(){
 		byte[] minShrineLevelBytes = new byte[TomeOfKnowledge.NUMBER_OF_SHRINES];
 		for(int i = 0; i < TomeOfKnowledge.NUMBER_OF_SHRINES; i++){
@@ -136,7 +136,7 @@ public class ShrinesStore {
 		}
 		return minShrineLevelBytes;
 	}
-	
+
 	private byte[] getMaxShrineLevelBytes(){
 		byte[] maxShrineLevelBytes = new byte[TomeOfKnowledge.NUMBER_OF_SHRINES];
 		for(int i = 0; i < TomeOfKnowledge.NUMBER_OF_SHRINES; i++){
@@ -145,7 +145,7 @@ public class ShrinesStore {
 		}
 		return maxShrineLevelBytes;
 	}
-	
+
 	private byte[] getGameTypesInWhichPresentBytes(){
 		byte[] gameTypesInWhichPresentBytes = new byte[TomeOfKnowledge.NUMBER_OF_SHRINES];
 		for(int i = 0; i < TomeOfKnowledge.NUMBER_OF_SHRINES; i++){
@@ -161,44 +161,44 @@ public class ShrinesStore {
 
 	public void writeShrinesToEXE() {
 		ShrinesAsBytes sab = this.getShrinesAsBytes();
-		
+
 		byte[] shrinePointerBytes = sab.getShrinePointerBytes();
 		rw.writeBytes(shrinePointerBytes, TomeOfKnowledge.SHRINE_POINTERS_OFFSET);
-		
+
 		byte[] minShrineLevelBytes = sab.getMinShrineLevelBytes();
 		rw.writeBytes(minShrineLevelBytes, TomeOfKnowledge.SHRINE_MIN_LEVELS_OFFSET);
-		
+
 		byte[] maxShrineLevelBytes = sab.getMaxShrineLevelBytes();
 		rw.writeBytes(maxShrineLevelBytes, TomeOfKnowledge.SHRINE_MAX_LEVELS_OFFSET);
-		
+
 		byte[] gameTypesInWhichPresentBytes = sab.getGameTypeBytes();
 		rw.writeBytes(gameTypesInWhichPresentBytes, TomeOfKnowledge.SHRINE_GAME_TYPE_OFFSET);
 	}
-	
+
 	void disableBadShrines() {
 		Shrine hiddenShrine = this.getShrine(1);
 		hiddenShrine.setMinShrineLevel(0);
 		hiddenShrine.setMaxShrineLevel(0);
-		
+
 		Shrine fascinatingShrine = this.getShrine(9);
 		fascinatingShrine.setMinShrineLevel(0);
 		fascinatingShrine.setMaxShrineLevel(0);
-		
+
 		Shrine sacredShrine = this.getShrine(16);
 		sacredShrine.setMinShrineLevel(0);
 		sacredShrine.setMaxShrineLevel(0);
-		
+
 		Shrine secludedShrine = this.getShrine(22);
 		secludedShrine.setMinShrineLevel(0);
 		secludedShrine.setMaxShrineLevel(0);
-		
+
 		Shrine ornateShrine = this.getShrine(23);
 		ornateShrine.setMinShrineLevel(0);
 		ornateShrine.setMaxShrineLevel(0);
-		
+
 		Shrine taintedShrine = this.getShrine(25);
 		taintedShrine.setMinShrineLevel(0);
 		taintedShrine.setMaxShrineLevel(0);
-		
+
 	}
 }

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/SpecialEffect.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/SpecialEffect.java
@@ -4,7 +4,7 @@ public class SpecialEffect {
 
 	private int refCode;
 	private String description;
-	
+
 	public int getRefCode() {
 		return refCode;
 	}

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/Spell.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/Spell.java
@@ -7,7 +7,7 @@ public class Spell {
 
 	private int unmoddedSpellIndex;
 	private int manaToCast;
-	private int animatiyonWhenCasting;
+	private int animationWhenCasting;
 	private long pointerToNameAsSpell;
 	private String nameAsSpell;
 	private long pointerToNameAsSkill;
@@ -216,9 +216,9 @@ public class Spell {
 			"Resurrect (sun ray)", //3E
 			"Bone Spirit", // 3F
 			"charged bolt..small...on caster..no damage", //40
-			"Unholy Altar portal (no effect)"//41
-			"Apocalypse Fireplar?"//42
-			"Apocalypse Fireplar?"//43
+			"Unholy Altar portal (no effect)",//41
+			"Apocalypse Fireplar?",//42
+			"Apocalypse Fireplar?" //43
 		};
 		return spellEffects;
 	}

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/Spell.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/Spell.java
@@ -4,10 +4,10 @@ public class Spell {
 
 	String[] castingSounds = {"Fire", "Lighting", "Utility", "Other"};
 	String[] animationsWhenCasting = {"fire", "lightning", "magic/other"};
-	
+
 	private int unmoddedSpellIndex;
 	private int manaToCast;
-	private int animationWhenCasting;
+	private int animatiyonWhenCasting;
 	private long pointerToNameAsSpell;
 	private String nameAsSpell;
 	private long pointerToNameAsSkill;
@@ -32,7 +32,7 @@ public class Spell {
 	private long staffCostMultiplier;
 	//private byte[] spellBytes;
 	int index;
-	
+
 	public Spell(int index, byte[] byteArray, ReaderWriter rw) {
 		this.index = index+1; //spell index starts from 1, loop in SpellsStore starts from 0
 		if(byteArray.length != 56){
@@ -83,7 +83,7 @@ public class Spell {
 		bookCost = rw.convertFourBytesToNumber(byteArray[48], byteArray[49], byteArray[50], byteArray[51]);
 		staffCostMultiplier = rw.convertFourBytesToNumber(byteArray[52], byteArray[53], byteArray[54], byteArray[55]);
 	}
-	
+
 	//TODO -- refactor duplicate code (is in Spell and ShrinesStore)
 	private String getNameUsingPointer(long pointer){
 		ReaderWriter rwTemp = new ReaderWriter(true);
@@ -148,7 +148,7 @@ public class Spell {
 		System.out.println("Staff cost multiplier: " + staffCostMultiplier);
 		System.out.println();
 	}
-	
+
 	private String[] createSpellEffectsArray() {
 		String[] spellEffects = {
 			"Misc effect", //00
@@ -160,67 +160,69 @@ public class Spell {
 			"Fireball", //06
 			"Lightning", //07
 			"Lightning Trap (no damage)", //08
-			"No effect ???", //09
+			"Magblos?", //09
 			"Town Portal", //0A
-			"Flash (1 side)", //0B
-			"Flash (other side)", //OC
+			"Flash (bottom side)", //0B
+			"Flash (top side)", //OC
 			"Mana Shield", //0D
 			"Another type of Flame Wave", //0E
 			"Chain Lightning", //0F
 			"Crash!!!", //10
-			"Some funny sound", //11
+			"Blood", //11
 			"looks like the impact of the Bone Spirit spell", //12
 			"Stone Curse dust??", //13
-			"No effect", //14
-			"", //15
-			"", //16
-			"No effect", //17
+			"Gloom?", //14
+			"Magball?", //15
+			"Thin lightning (many)", //16
+			"Thin lightning", //17
 			"Blood Star", //18
-			"No effect", //19
+			"Flare explosion", //19
 			"Teleport", //1A
 			"Fire Arrow", //1B
-			"Crash!!", //1C
+			"Doom", //1C
 			"Another Fire Trap", //1D
 			"Stone Curse", //1E
 			"No effect", //1F
-			"Unknown", //20
+			"Invisible", //20
 			"Golem", //21
 			"Etherealize", //22
-			"", //23
-			"", //24
+			"Blodbur?", //23
+			"Apocalypse?", //24
 			"Healing", //25
-			"FireWall", //26
+			"Fire Wall", //26
 			"Infravision", //27
 			"Identify", //28
 			"Flame Wave", //29
 			"Nova", //2A
-			"", //2B
+			"Blood Boil", //2B
 			"Apocalypse", //2C
-			"Item Repair",
-			"Staff Recharge",
-			"Trap Disarm",
-			"Inferno?",
-			"Inferno",
-			"",
-			"",
-			"Charged Bolt",
-			"Holy Bolt",
-			"Resurrect",
-			"Telekinesis",
-			"",
-			"",
-			"",
-			"",
-			"Heal Other",
-			"Elemental",
-			"Another type of res?",
-			"Bone Spirit",
-			"charged bolt..small...on caster..no damage",
-			"Unholy Altar portal (no effect)"
+			"Item Repair", //2D
+			"Staff Recharge", //2E
+			"Trap Disarm", //2F
+			"Inferno?", //30
+			"Inferno", //31
+			"Golem?", //32
+			"Krull", //33
+			"Charged Bolt", //34
+			"Holy Bolt", //35
+			"Resurrect", //36
+			"Telekinesis", //37
+			"Lightning arrow", //38
+			"Acid bf?", //39
+			"Acid splash", //3A
+			"Acid pud", //3B
+			"Heal Other", //3C
+			"Elemental", //3D
+			"Resurrect (sun ray)", //3E
+			"Bone Spirit", // 3F
+			"charged bolt..small...on caster..no damage", //40
+			"Unholy Altar portal (no effect)"//41
+			"Apocalypse Fireplar?"//42
+			"Apocalypse Fireplar?"//43
 		};
 		return spellEffects;
 	}
-	
+
 	public byte[] getSpellAsBytes() {
 		byte[] spellAsBytes = new byte[56];
 		spellAsBytes[0] = (byte) unmoddedSpellIndex;
@@ -293,11 +295,11 @@ public class Spell {
 		spellAsBytes[53] = (byte) (staffCostMultiplier >>> 8); //staffCostMultiplier
 		spellAsBytes[54] = (byte) (staffCostMultiplier >>> 16); //staffCostMultiplier
 		spellAsBytes[55] = (byte) (staffCostMultiplier >>> 24); //staffCostMultiplier
-		
+
 		//System.out.println("ORIG: " + Arrays.toString(spellBytes));
 		//System.out.println("BACK: " + Arrays.toString(spellAsBytes));
 		//System.out.println();
-		
+
 		return spellAsBytes;
 	}
 

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/SpellsStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/SpellsStore.java
@@ -7,13 +7,13 @@ public class SpellsStore {
 
 	ReaderWriter rw = null;
 	List<Spell> spells = null;
-	
+
 	public SpellsStore(ReaderWriter rw){
 		this.rw = rw;
 		this.spells = new ArrayList<Spell>();
 		this.readInSpells();
 	}
-	
+
 	public void readInSpells(){
 		long pos = TomeOfKnowledge.SPELLS_OFFSET; //skills
 		long spacing = 56l;
@@ -22,7 +22,7 @@ public class SpellsStore {
 			pos = pos + spacing;
 		}
 	}
-	
+
 	private void readSpell(long position, int index) {
 		long pos = position;
 		rw.seek(position);
@@ -33,11 +33,11 @@ public class SpellsStore {
 			rw.seek(pos);
 			readIn[i] = rw.readByte();
 		}
-		
+
 		Spell s = new Spell(index, readIn, rw);
 		spells.add(s);
-		
-		
+
+
 	}
 
 	public void printSpells() {
@@ -56,6 +56,6 @@ public class SpellsStore {
 			byte[] spellAsBytes = this.getSpellAsBytes(i);
 			rw.writeBytes(spellAsBytes, pos);
 			pos = pos + TomeOfKnowledge.SPELL_LENGTH_IN_BYTES;
-		}		
+		}
 	}
 }

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/TomeOfKnowledge.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/TomeOfKnowledge.java
@@ -5,34 +5,34 @@ public class TomeOfKnowledge {
 	public static final long QUESTS_OFFSET = 653536l;
 	public static final int NUMBER_OF_QUESTS = 16;
 	public static final int QUEST_LENGTH_IN_BYTES = 16;
-	
+
 	public static final long SPELLS_OFFSET = 655872l;
 	public static final int NUMBER_OF_SPELLS = 36;
 	public static final int SPELL_LENGTH_IN_BYTES = 56;
-	
+
 	public static final long SHRINE_POINTERS_OFFSET = 648827l; //648831l;
 	public static final long SHRINE_MIN_LEVELS_OFFSET = 648932l;
 	public static final long SHRINE_MAX_LEVELS_OFFSET = 648960l;
 	public static final long SHRINE_GAME_TYPE_OFFSET = 648990l;
 	public static final int NUMBER_OF_SHRINES = 26;
-	
+
 	public static final long MODIFIERS_OFFSET = 498344l;
 	public static final int NUMBER_OF_MODIFIERS = 83;
 	public static final int MODIFIER_LENGTH_IN_BYTES = 48;
 	public static final int NUMBER_OF_ITEM_EFFECTS = 4;
-	
+
 	public static final long DIABLO_POINTERS_OFFSET = 4203008l;
 	public static final long HELLFIRE_POINTERS_OFFSET = 4199936l;
-	
+
 	public static final long UNIQUE_ITEMS_OFFSET = 506984;
 	public static final int UNIQUE_ITEM_LENGTH_IN_BYTES = 84;
 	public static final int NUMBER_OF_UNIQUE_ITEMS = 50;
-	
+
 	public static final long MIN_STATS_OFFSET = 650716;
 	public static final long MAX_STATS_OFFSET = 650788;
 	public static final long BLOCKING_BONUSES_OFFSET = 650764;
 	public static final int BONUSES_AND_FRAMESETS_OFFSET = 650632;
-	
+
 	public static final long CHARACTER_ZERO_SKILL_LOC_1 = 305285; //1024 (hex editor) <=> 4198400 (asm) [-s 4197376 or 0x0400C00]
 	public static final long CHARACTER_ZERO_SKILL_LOC_2 = 306884;
 	public static final long CHARACTER_ZERO_SPELL_LOC_1 = 15564;
@@ -42,21 +42,21 @@ public class TomeOfKnowledge {
 	public static final long CHARACTER_TWO_SKILL_LOC_1 = 305392;
 	public static final long CHARACTER_TWO_SKILL_LOC_2 = 306910;
 	public static final long CHARACTER_TWO_SPELL_LOC_1 = 15590;
-	
-	
+
+
 	public static final long BASE_ITEMS_OFFSET = 578568;
 	public static final int BASE_ITEM_LENGTH_IN_BYTES = 76;
 	public static final int NUMBER_OF_BASE_ITEMS = 35;
-	
+
 	public static final long BASE_MONSTERS_OFFSET = 613384;
 	public static final int BASE_MONSTER_LENGTH_IN_BYTES = 128;
 	public static final int NUMBER_OF_BASE_MONSTERS = 111;
 	public static final long MONSTER_ACTIVATION_BYTES_OFFSET = 627848;
-	
+
 	public static final long UNIQUE_MONSTERS_OFFSET = 627960;
 	public static final int NUMBER_OF_UNIQUE_MONSTERS = 97;
 	public static final int UNIQUE_MONSTER_LENGTH_IN_BYTES = 32;
-	
+
 	static String[] createSpellNamesArray(){
 		String[] spellNames = new String[37];
 		spellNames[0] = "none";
@@ -65,13 +65,13 @@ public class TomeOfKnowledge {
 		spellNames[3] = "Lightning";
 		spellNames[4] = "Flash";
 		spellNames[5] = "Identify";
-		spellNames[6] = "FireWall";
+		spellNames[6] = "Fire Wall";
 		spellNames[7] = "Town Portal";
 		spellNames[8] = "Stone Curse";
 		spellNames[9] = "Infravision";
 		spellNames[10] = "Phasing";
 		spellNames[11] = "Mana Shield";
-		spellNames[12] = "FireBall";
+		spellNames[12] = "Fireball";
 		spellNames[13] = "Guardian";
 		spellNames[14] = "Chain Lightning";
 		spellNames[15] = "Flame Wave";

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueItem.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueItem.java
@@ -27,7 +27,7 @@ public class UniqueItem {
 	private long minValueSix;
 	private long maxValueSix;
 	//private byte[] itemBytes;
-	
+
 	public UniqueItem(byte[] readIn, ReaderWriter rw){
 		//this.itemBytes = readIn;
 		namePointer = rw.convertFourBytesToOffset(readIn[0], readIn[1], readIn[2], readIn[3]);
@@ -55,7 +55,7 @@ public class UniqueItem {
 		minValueSix = rw.convertFourBytesToNumber(readIn[76], readIn[77], readIn[78], readIn[79]);
 		maxValueSix = rw.convertFourBytesToNumber(readIn[80], readIn[81], readIn[82], readIn[83]);
 	}
-	
+
 	public void printItem() {
 		System.out.println("Name: " + name);
 		System.out.println("Name pointer: " + namePointer);
@@ -73,7 +73,7 @@ public class UniqueItem {
 		System.out.println("Effect six: " + effectsArray[(int) effectSix] +"; " + minValueSix +"; " + effectSix);
 		System.out.println();
 	}
-	
+
 	//TODO -- fix duplicate code
 	private String[] createNewItemEffectsArray() {
 		String[] itemEffects = {
@@ -160,7 +160,7 @@ public class UniqueItem {
 		};
 		return itemEffects;
 	}
-	
+
 	public static String[] createNewItemTypeArray(){
 		String[] uniqueItemTypesArray = {
 			"nullString", //0
@@ -235,7 +235,7 @@ public class UniqueItem {
 		};
 		return uniqueItemTypesArray;
 	}
-	
+
 	//TODO -- refactor duplicate code (is in Spell and ShrinesStore and ItemModifier)
 	private String getNameUsingPointer(long pointer){
 		ReaderWriter rwTemp = new ReaderWriter(true);
@@ -344,11 +344,11 @@ public class UniqueItem {
 		itemAsBytes[81] = (byte) (maxValueSix >>> 8);
 		itemAsBytes[82] = (byte) (maxValueSix >>> 16);
 		itemAsBytes[83] = (byte) (maxValueSix >>> 24);
-		
+
 		//System.out.println("ORIG: " + Arrays.toString(itemBytes));
 		//System.out.println("BACK: " + Arrays.toString(itemAsBytes));
 		//System.out.println();
-		
+
 		return itemAsBytes;
 	}
 

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueItemStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueItemStore.java
@@ -7,7 +7,7 @@ public class UniqueItemStore {
 
 	ReaderWriter rw;
 	List<UniqueItem> uniqueItems;
-	
+
 	public UniqueItemStore(ReaderWriter rw){
 		this.rw = rw;
 		uniqueItems = new ArrayList<UniqueItem>();
@@ -22,7 +22,7 @@ public class UniqueItemStore {
 			pos = pos + spacing;
 		}
 	}
-	
+
 	private void readItem(long position){
 		long pos = position;
 		rw.seek(pos);
@@ -32,7 +32,7 @@ public class UniqueItemStore {
 			pos++;
 			rw.seek(pos);
 		}
-		
+
 		UniqueItem ui = new UniqueItem(readIn, rw);
 		uniqueItems.add(ui);
 	}
@@ -53,6 +53,6 @@ public class UniqueItemStore {
 			byte[] itemAsBytes = this.getItemAsBytes(i);
 			rw.writeBytes(itemAsBytes, pos);
 			pos = pos + TomeOfKnowledge.UNIQUE_ITEM_LENGTH_IN_BYTES;
-		}	
+		}
 	}
 }

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueMonster.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueMonster.java
@@ -2,6 +2,41 @@ package uk.me.karlsen.ode;
 
 public class UniqueMonster {
 
+	String[] monsterAIs = {
+		"Zombie",
+		"Overlord",
+		"Skeleton",
+		"Skeleton Archer",
+		"Scavenger",
+		"Horned Demon",
+		"Goat Man",
+		"Goat Man Archer",
+		"Fallen One",
+		"Magma Demon",
+		"Skeleton King",
+		"Winged Fiend",
+		"Gargoyle",
+		"The Butcher",
+		"Succubus",
+		"Hidden",
+		"Lightning Demon",
+		"Fireman",
+		"Gharbad the Weak",
+		"Spitting Terror",
+		"Fast Spitting Terror",
+		"Golem",
+		"Zhar the Mad",
+		"Snotspill",
+		"Viper",
+		"Mage",
+		"Balrog",
+		"The Dark Lord",
+		"Arch Bishop Lazarus",
+		"Unique Succubus",
+		"Lachdanan",
+		"Warlord of Blood"
+	}
+
 	private long monsterType;
 	private long namePointer;
 	private String name;
@@ -9,8 +44,8 @@ public class UniqueMonster {
 	private String trnName;
 	private int dungeonLevel;
 	private int hitPoints;
-	private int attackTypePart1;
-	private int attackTypePart2;
+	private int monsterAI;
+	private int intelligenceFactor;
 	private int minAttackDmg;
 	private int maxAttackDmg;
 	private String resistances;
@@ -18,7 +53,7 @@ public class UniqueMonster {
 	private long packSpecials;
 	private long specialSoundWav;
 	//byte[] uniqueBytes;
-	
+
 	public UniqueMonster(byte[] monsterBytes, ReaderWriter rw) {
 		//uniqueBytes = monsterBytes;
 		BinEditHelper nf = new BinEditHelper();
@@ -29,8 +64,8 @@ public class UniqueMonster {
 		trnName = nf.getNameUsingPointer(trnPointer);
 		dungeonLevel = rw.convertTwoBytesToInt(monsterBytes[12], monsterBytes[13]);
 		hitPoints = rw.convertTwoBytesToInt(monsterBytes[14], monsterBytes[15]);
-		attackTypePart1 = rw.convertUnsignedByteToInt(monsterBytes[16]);
-		attackTypePart2 = rw.convertUnsignedByteToInt(monsterBytes[17]);
+		monsterAI = rw.convertUnsignedByteToInt(monsterBytes[16]);
+		intelligenceFactor = rw.convertUnsignedByteToInt(monsterBytes[17]);
 		minAttackDmg = rw.convertUnsignedByteToInt(monsterBytes[18]);
 		maxAttackDmg = rw.convertUnsignedByteToInt(monsterBytes[19]);
 		resistances = String.format("%16s", Integer.toBinaryString(rw.convertUnsignedByteToInt(monsterBytes[20]))).replace(' ', '0') + ";" +
@@ -48,8 +83,8 @@ public class UniqueMonster {
 		System.out.println("TRN file: " + trnName);
 		System.out.println("Dungeon level: " + dungeonLevel);
 		System.out.println("HPs: " + hitPoints);
-		System.out.println("Attack type part 1: " + attackTypePart1);
-		System.out.println("Attack type part 2: " + attackTypePart2);
+		System.out.println("Monster AI: " + monsterAIs[monsterAI]);
+		System.out.println("Intelligence factor: " + intelligenceFactor);
 		System.out.println("Min attack dmg: " + minAttackDmg);
 		System.out.println("Max attack dmg: " + maxAttackDmg);
 		System.out.println("Resistances: " + resistances);
@@ -79,8 +114,8 @@ public class UniqueMonster {
 		uniqueAsBytes[13] = (byte) (dungeonLevel >>> 8);
 		uniqueAsBytes[14] = (byte) (hitPoints >>> 0);
 		uniqueAsBytes[15] = (byte) (hitPoints >>> 8);
-		uniqueAsBytes[16] = (byte) attackTypePart1;
-		uniqueAsBytes[17] = (byte) attackTypePart2;
+		uniqueAsBytes[16] = (byte) monsterAI;
+		uniqueAsBytes[17] = (byte) intelligenceFactor;
 		uniqueAsBytes[18] = (byte) minAttackDmg;
 		uniqueAsBytes[19] = (byte) maxAttackDmg;
 		String[] resistancesSplit = resistances.split(";");
@@ -96,11 +131,11 @@ public class UniqueMonster {
 		uniqueAsBytes[29] = (byte) (specialSoundWav >>> 8);
 		uniqueAsBytes[30] = (byte) (specialSoundWav >>> 16);
 		uniqueAsBytes[31] = (byte) (specialSoundWav >>> 24);
-		
+
 		//System.out.println("ORIG: " + Arrays.toString(uniqueBytes));
 		//System.out.println("BACK: " + Arrays.toString(uniqueAsBytes));
 		//System.out.println();
-		
+
 		return uniqueAsBytes;
 	}
 
@@ -160,20 +195,20 @@ public class UniqueMonster {
 		this.hitPoints = hitPoints;
 	}
 
-	public int getAttackTypePart1() {
-		return attackTypePart1;
+	public int getMonsterAI() {
+		return monsterAI;
 	}
 
-	public void setAttackTypePart1(int attackTypePart1) {
-		this.attackTypePart1 = attackTypePart1;
+	public void setMonsterAI(int monsterAI) {
+		this.monsterAI = monsterAI;
 	}
 
-	public int getAttackTypePart2() {
-		return attackTypePart2;
+	public int getIntelligenceFactor() {
+		return intelligenceFactor;
 	}
 
-	public void setAttackTypePart2(int attackTypePart2) {
-		this.attackTypePart2 = attackTypePart2;
+	public void setIntelligenceFactor(int intelligenceFactor) {
+		this.intelligenceFactor = intelligenceFactor;
 	}
 
 	public int getMinAttackDmg() {

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueMonster.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueMonster.java
@@ -35,7 +35,7 @@ public class UniqueMonster {
 		"Unique Succubus",
 		"Lachdanan",
 		"Warlord of Blood"
-	}
+	};
 
 	private long monsterType;
 	private long namePointer;

--- a/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueMonsterStore.java
+++ b/OpenDiabloEditor/src/uk/me/karlsen/ode/UniqueMonsterStore.java
@@ -7,7 +7,7 @@ public class UniqueMonsterStore {
 
 	ReaderWriter rw;
 	List<UniqueMonster> uniqueMonsters;
-	
+
 	public UniqueMonsterStore(ReaderWriter rw) {
 		this.rw = rw;
 		uniqueMonsters = new ArrayList<UniqueMonster>();
@@ -31,7 +31,7 @@ public class UniqueMonsterStore {
 		for(UniqueMonster um : uniqueMonsters){
 			um.printItem();
 		}
-		
+
 	}
 
 	public byte[] getUniqueAsBytes(int i) {
@@ -45,7 +45,7 @@ public class UniqueMonsterStore {
 			rw.writeBytes(uniqueAsBytes, pos);
 			pos = pos + TomeOfKnowledge.UNIQUE_MONSTER_LENGTH_IN_BYTES;
 		}
-		
+
 	}
 
 }


### PR DESCRIPTION
BaseItem:

* Add two special effects comments.
* Pretty-print quality levels, and add TODO regarding its byte representation.

BaseMonster:

* Fix error message of setMonsterType.
* Add TODO regarding monsterItemLevel's byte representation.

ItemModifier:

* Add TODO to reuse shared code by implementing an ItemEffect class.
* Fix spelling and improve precision of the item modifier.

Quest:

* Add the dungeonLevelSingle, dungeonLevelMulti, dungeonType, textEntryIDX members to Quest.

QuestStore:

* Update comment about the Quest structure.

Spell:

* Update spell effects names.

TomeOfKnowledge:

* Fix spelling and remove trailing whitespace.

UniqueMonster:

* Add monsterAI and intelligenceFactor fields to UniqueMonster.

all:

* Remove trailing whitespace.
